### PR TITLE
regenerate: quote and 1/4 unicode item fix

### DIFF
--- a/doc/vim_faq.txt
+++ b/doc/vim_faq.txt
@@ -114,12 +114,12 @@ SECTION 8 - BUFFERS ~
 	  number?
 |faq-8.5|   How do I open all the current buffers in separate windows?
 |faq-8.6|   How do I close (delete) a buffer without exiting Vim?
-|faq-8.7|   When I use the command ":%bd" to delete all the buffers, not all
+|faq-8.7|   When I use the command `:%bd` to delete all the buffers, not all
 	  the buffers are deleted. Why?
 |faq-8.8|   How do I display the buffer number of the current buffer/file?
 |faq-8.9|   How do I delete a buffer without closing the window in which the
 	  buffer is displayed?
-|faq-8.10|  How do I map the tab key to cycle through and open all the
+|faq-8.10|  How do I map the <Tab> key to cycle through and open all the
 	  buffers?
                                                                 *faq-windows*
 SECTION 9 - WINDOWS ~
@@ -167,8 +167,8 @@ SECTION 11 - SEARCHING TEXT ~
 	  stays highlighted. How do I turn off the highlighting
 	  temporarily/permanently?
 |faq-11.2|  How do I enter a carriage return character in a search pattern?
-|faq-11.3|  How do I search for the character ^M?
-|faq-11.4|  How can I search/replace characters that display as '~R', '~S',
+|faq-11.3|  How do I search for the character "^M"?
+|faq-11.4|  How can I search/replace characters that display as "~R", "~S",
 	  etc.?
 |faq-11.5|  How do I highlight all the non-printable characters in a file?
 |faq-11.6|  How do I search for whole words in a file?
@@ -183,7 +183,7 @@ SECTION 11 - SEARCHING TEXT ~
 |faq-11.12| How do I search for an empty line?
 |faq-11.13| How do I search for a line containing only a single character?
 |faq-11.14| How do I search and replace a string in multiple files?
-|faq-11.15| I am using the ":s" substitute command in a mapping. When a
+|faq-11.15| I am using the `:s` substitute command in a mapping. When a
 	  search for a pattern fails, the map terminates. I would like the
 	  map to continue processing the next command, even if the
 	  substitute command fails. How do I do this?
@@ -199,8 +199,8 @@ SECTION 11 - SEARCHING TEXT ~
 |faq-11.22| How do I search for a pattern only within a range of lines
 	  in a buffer?
 |faq-11.23| How do I clear the last searched pattern?
-|faq-11.24| Why does this pattern 'a.\{-}p\@!' not match?
-|faq-11.25| How can I use '/' within a pattern, without escaping it?
+|faq-11.24| Why does this pattern "a.\{-}p\@!" not match?
+|faq-11.25| How can I use "/" within a pattern, without escaping it?
 |faq-11.26| How can I operate on a search match?
                                                         *faq-changing-text*
 SECTION 12 - CHANGING TEXT ~
@@ -242,9 +242,9 @@ SECTION 12 - CHANGING TEXT ~
 	  directory?
 |faq-12.21| I have some numbers in a file. How do I increment or decrement
 	  the numbers in the file?
-|faq-12.22| How do I reuse the last used search pattern in a ":substitute"
+|faq-12.22| How do I reuse the last used search pattern in a `:substitute`
 	  command?
-|faq-12.23| How do I change the case of a string using the ":substitute"
+|faq-12.23| How do I change the case of a string using the `:substitute`
 	  command?
 |faq-12.24| How do I enter characters that are not present in the keyboard?
 |faq-12.25| Is there a command to remove any or all digraphs?
@@ -277,7 +277,7 @@ SECTION 14 - TEXT FORMATTING ~
 |faq-14.1|  How do I format a text paragraph so that a new line is inserted
 	  at the end of each wrapped line?
 |faq-14.2|  How do I format long lines in a file so that each line contains
-	  less than 'n' characters?
+	  less than "n" characters?
 |faq-14.3|  How do I join short lines to the form a paragraph?
 |faq-14.4|  How do I format bulleted and numbered lists?
 |faq-14.5|  How do I indent lines in insert mode?
@@ -299,8 +299,8 @@ SECTION 14 - TEXT FORMATTING ~
 	  messed up. How do I fix this?
 |faq-14.15| When there is a very long wrapped line (wrap is "on") and a line
 	  doesn't fit entirely on the screen it is not displayed at all.
-	  There are blank lines beginning with '@' symbol instead of
-	  wrapped line. If I scroll the screen to fit the line the '@'
+	  There are blank lines beginning with "@" symbol instead of
+	  wrapped line. If I scroll the screen to fit the line the "@"
 	  symbols disappear and the line is displayed again. What Vim
 	  setting control this behavior?
 |faq-14.16| How do I convert all the tab characters in a file to space
@@ -335,7 +335,7 @@ SECTION 16 - COMMAND-LINE MODE ~
 |faq-16.2|  How do I edit the text in the Vim command-line effectively?
 |faq-16.3|  How do I switch from Vi mode to Ex mode?
 |faq-16.4|  How do I copy the output from an ex-command into a buffer?
-|faq-16.5|  When I press the tab key to complete the name of a file in the
+|faq-16.5|  When I press the <Tab> key to complete the name of a file in the
 	  command mode, if there are more than one matching file names,
 	  then Vim completes the first matching file name and displays a
 	  list of all matching filenames. How do I configure Vim to only
@@ -371,7 +371,7 @@ SECTION 19 - OPTIONS ~
 |faq-19.5|  Can I add (embed) Vim option settings to the contents of a file?
 |faq-19.6|  How do I display the line numbers of all the lines in a file?
 |faq-19.7|  How do I change the width of the line numbers displayed using the
-	  "number" option?
+	  'number' option?
 |faq-19.8|  How do I display (view) all the invisible characters like space,
 	  tabs and newlines in a file?
 |faq-19.9|  How do I configure Vim to always display the current line and
@@ -386,9 +386,9 @@ SECTION 19 - OPTIONS ~
 	  invocations/instances/sessions?
 |faq-19.15| Why do I hear a beep (why does my window flash) about 1 second
 	  after I hit the Escape key?
-|faq-19.16| How do I make the 'c' and 's' commands display a '$' instead of
+|faq-19.16| How do I make the "c" and "s" commands display a "$" instead of
 	  deleting the characters I'm changing?
-|faq-19.17| How do I remove more than one flag using a single ":set" command
+|faq-19.17| How do I remove more than one flag using a single `:set` command
 	  from a Vim option?
                                                         *faq-mapping-keys*
 SECTION 20 - MAPPING KEYS ~
@@ -406,14 +406,14 @@ SECTION 20 - MAPPING KEYS ~
 	  so that the mapped key will not collide with an already used key?
 |faq-20.10| How do I map the escape key?
 |faq-20.11| How do I map a key to perform nothing?
-|faq-20.12| I want to use the Tab key to indent a block of text and
-	  Shift-Tab key to unindent a block of text. How do I map the keys
+|faq-20.12| I want to use the <Tab> key to indent a block of text and
+	  <Shift-Tab> key to unindent a block of text. How do I map the keys
 	  to do this?  This behavior is similar to textpad, visual studio,
 	  etc.
 |faq-20.13| In my mappings the special characters like <CR> are not
 	  recognized. How can I configure Vim to recognize special
 	  characters?
-|faq-20.14| How do I use the '|' to separate multiple commands in a map?
+|faq-20.14| How do I use the "|" to separate multiple commands in a map?
 |faq-20.15| If I have a mapping/abbreviation whose ending is the beginning of
 	  another mapping/abbreviation, how do I keep the first from
 	  expanding into the second one?
@@ -421,7 +421,7 @@ SECTION 20 - MAPPING KEYS ~
 	  sometimes when I press a key?
 |faq-20.17| How do I map a key to run an external command using a visually
 	  selected text?
-|faq-20.18| How do I map the Ctrl-I key while still retaining the
+|faq-20.18| How do I map the CTRL-I key while still retaining the
 	  functionality of the <Tab> key?
 |faq-20.19| How do I define a map to accept a count?
 |faq-20.20| How can I make my normal mode mapping work from within Insert
@@ -464,7 +464,7 @@ SECTION 24 - SYNTAX HIGHLIGHT ~
 |faq-24.3|  How do I change the highlight colors to suit a dark/light
 	  background?
 |faq-24.4|  How do I change the color of the line numbers displayed when the
-	  ":set number" command is used?
+	  `:set number` command is used?
 |faq-24.5|  How do I change the background color used for a Visually selected
 	  block?
 |faq-24.6|  How do I highlight the special characters (tabs, trailing spaces,
@@ -511,9 +511,9 @@ SECTION 25 - VIM SCRIPT WRITING ~
 	  mode commands?
 |faq-25.12| How do I get a visually selected text into a Vim variable or
 	  register?
-|faq-25.13| I have some text in a Vim variable 'myvar'. I would like to use
-	  this variable in a ":s" substitute command to replace a text
-	  'mytext'. How do I do this?
+|faq-25.13| I have some text in a Vim variable "myvar". I would like to use
+	  this variable in a `:s` substitute command to replace a text
+	  "mytext". How do I do this?
 |faq-25.14| A Vim variable (bno) contains a buffer number. How do I use this
 	  variable to open the corresponding buffer?
 |faq-25.15| How do I store the value of a Vim option into a Vim variable?
@@ -527,18 +527,18 @@ SECTION 25 - VIM SCRIPT WRITING ~
 	  buffer?
 |faq-25.21| How do I call external programs from a Vim function?
 |faq-25.22| How do I get the return status of a program executed using the
-	  ":!" command?
+	  `:!` command?
 |faq-25.23| How do I determine whether the current buffer is modified or
 	  not?
 |faq-25.24| I would like to use the carriage return character in a normal
 	  command from a Vim script. How do I specify the carriage return
 	  character?
 |faq-25.25| How do I split long lines in a Vim script?
-|faq-25.26| When I try to "execute" my function using the "execute Myfunc()"
+|faq-25.26| When I try to "execute" my function using the `:execute Myfunc()`
 	  command, the cursor is moved to the top of the current buffer.
 	  Why?
 |faq-25.27| How do I source/execute the contents of a register?
-|faq-25.28| After calling a Vim function or a mapping, when I press the 'u'
+|faq-25.28| After calling a Vim function or a mapping, when I press the "u"
 	  key to undo the last change, Vim undoes all the changes made by
 	  the mapping/function. Why?
 |faq-25.29| How can I call a function defined with s: (script local
@@ -574,7 +574,7 @@ SECTION 27 - EDITING PROGRAM FILES ~
 	  below a comment (//) line, Vim automatically inserts the C++
 	  comment character (//) at the beginning of the line. How do I
 	  disable this? 
-|faq-27.8|  How do I add the comment character '#' to a set of lines at the
+|faq-27.8|  How do I add the comment character "#" to a set of lines at the
 	  beginning of each line?
 |faq-27.9|  How do I edit a header file with the same name as the
 	  corresponding C source file?
@@ -585,7 +585,7 @@ SECTION 28 - QUICKFIX ~
 |faq-28.1|  How do I build programs from Vim?
 |faq-28.2|  When I run the make command in Vim I get the errors listed as the
 	  compiler compiles the program. When it finishes this list
-	  disappears and I have to use the  :clist command to see the error
+	  disappears and I have to use the `:clist` command to see the error
 	  message again. Is there any other way to see these error
 	  messages?
 |faq-28.3|  How can I perform a command for each item in the
@@ -625,14 +625,14 @@ SECTION 31 - GUI VIM ~
 |faq-31.4|  How do I add a horizontal scrollbar in GVim?
 |faq-31.5|  How do I make the scrollbar appear in the left side by default?
 |faq-31.6|  How do I remove the Vim menubar?
-|faq-31.7|  I am using GUI Vim. When I press the ALT key and a letter, the
+|faq-31.7|  I am using GUI Vim. When I press the <Alt> key and a letter, the
 	  menu starting with that letter is selected. I don't want this
-	  behavior as I want to map the ALT-<key> combination. How do I do
+	  behavior as I want to map the <Alt>-<key> combination. How do I do
 	  this?
 |faq-31.8|  Is it possible to scroll the text by dragging the scrollbar so
 	  that the cursor stays in the original location?
 |faq-31.9|  How do I get gvim to start browsing files in a particular
-	  directory when using the ":browse" command?
+	  directory when using the `:browse` command?
 |faq-31.10| For some questions, like when a file is changed outside of Vim,
 	  Vim displays a GUI dialog box. How do I replace this GUI dialog
 	  box with a console dialog box?
@@ -665,7 +665,7 @@ SECTION 32 - VIM ON UNIX ~
 	  minimize the startup time?
 |faq-32.6|  How can I make the cursor in gvim in unix stop blinking?
 |faq-32.7|  How do I change the menu font on GTK Vim?
-|faq-32.8|  How do I prevent <Ctrl-Z> from suspending Vim?
+|faq-32.8|  How do I prevent CTRL-Z from suspending Vim?
 |faq-32.9|  When I kill the xterm running Vim, the Vim process continues to
 	  run and takes up a lot of CPU (99%) time. Why is this happening?
 |faq-32.10| How do I get the Vim syntax highlighting to work in a Unix
@@ -1191,11 +1191,11 @@ some configuration option inside your .vimrc file. Depending on the
 length of your vimrc file, it can be quite hard to trace the origin
 within that file.
 
-The best way is to add :finish command in the middle of your .vimrc.
+The best way is to add `:finish` command in the middle of your .vimrc.
 Then restart again using the same command line. If the error still
 occurs, the bug must be caused because of a setting in the first half of
 your .vimrc. If it doesn't happen, the problematic setting must be in
-the second half of your .vimrc. So move the :finish command to the
+the second half of your .vimrc. So move the `:finish` command to the
 middle of that half, of which you know that triggers the error and move
 your way along, until you find the problematic option. If your .vimrc is
 350 lines long, you need at a maximum 9 tries to find the offending line
@@ -1204,7 +1204,7 @@ depend on each other).
 
 If the problem does not occur, when only loading your .vimrc file, the
 error must be caused by a plugin or another runtime file (indent
-autoload or syntax script). Check the output of the :scriptnames command
+autoload or syntax script). Check the output of the `:scriptnames` command
 to see what files have been loaded and for each one try to disable each
 one by one and see which one triggers the bug. Often files that are
 loaded by vim, have a simple configuration variable to disable them, but
@@ -1400,6 +1400,7 @@ Amiga, Atari, BeOS, Macintosh, MachTen, OS/2, RiscOS, VMS, IBM z/OS.
 For MS-DOS support has been removed with the latest releases of Vim.
 16-bit DOS: latest supported version 7.1
 32-bit DOS: latest supported version 7.3
+
  								*faq-3.4*
 3.4. Where can I download the latest version of the Vim runtime files?
 
@@ -1426,25 +1427,26 @@ SECTION 4 - HELP ~
 4.1. How do I use the help files?
 
 Help can be found for all functions of Vim. In order to use it, use the
-":help" command.  This will bring you to the main help page. On that first
+`:help` command.  This will bring you to the main help page. On that first
 page, you will find explanations on how to move around. Basically, you move
 around in the help pages the same way you would in a read-only document.
 You can jump to specific subjects by using tags. This can be done in two
 ways:
 
-   * Use the "<Ctrl-]>" command while standing on the name of a command
+   * Use the CTRL-] command while standing on the name of a command
      or option. This only works when the tag is a keyword.
-     "<Ctrl-LeftMouse>" and "g<LeftMouse>" work just like "<Ctrl-]>".
+     <Ctrl-LeftMouse> and g<LeftMouse> work just like CTRL-].
 
-   * use the ":tag <subject>" command. This works with all characters.
+   * use the `:tag <subject>` command. This works with all characters.
 
-Use "<Ctrl-T>" to jump back to previous positions in the help files. Use
-":q" to close the help window.
+Use CTRL-T to jump back to previous positions in the help files. Use
+`:q` to close the help window.
 
-If you want to jump to a specific subject on the help pages, use ":help
-{subject}". If you don't know what to look for, try ":help index" to get a
-list of all available subjects. Use the standard search keys to locate the
-information you want. You can abbreviate the ":help" command as ":h".
+If you want to jump to a specific subject on the help pages, use
+`:help {subject}` . If you don't know what to look for, try `:help index`
+to get a list of all available subjects. Use the standard search keys to
+locate the information you want.
+You can abbreviate the `:help` command as `:h`.
 
 For searching the help, see the next Question 4.2. |faq-4.2|
 
@@ -1464,11 +1466,11 @@ a)  You can press the CTRL-D key after typing the help keyword to get a
     :help str*()<C-D>
     :help '*indent<C-D>
 <
-b)  You can press the Tab key after typing a partial help keyword to expand
-    to the matching keyword. You can continue to press the Tab key to see
+b)  You can press the <Tab> key after typing a partial help keyword to expand
+    to the matching keyword. You can continue to press the <Tab> key to see
     other keyword matches.
 
-c)  From the help window, you can use the ":tag" command to search for
+c)  From the help window, you can use the `:tag` command to search for
     keywords. For example, >
 
     :tselect /window
@@ -1476,7 +1478,7 @@ c)  From the help window, you can use the ":tag" command to search for
     This command will list all the help keywords containing the text
     "window". You can select one from the list and jump to it.
 
-d)  You can use the ":helpgrep" command to search for the given text in
+d)  You can use the `:helpgrep` command to search for the given text in
     all the help files. The quickfix window will be opened with all the
     matching lines.
 
@@ -1511,7 +1513,7 @@ You can get information about the different modes in Vim by reading
 4.5. How do I generate the Vim help tags file after adding a new Vim help
      file?
 
-You can use the ":helptags" command to regenerate the Vim help tag file
+You can use the `:helptags` command to regenerate the Vim help tag file
 from within Vim. For example: >
 
     :cd $VIMRUNTIME/doc
@@ -1547,7 +1549,7 @@ decompressing the files.  You must make sure that $VIMRUNTIME is set to
 where the other Vim files are, when they are not in the same location as
 the compressed "doc" directory.
 
-Note, that the :helpgrep command does not work with compressed help pages.
+Note, that the `:helpgrep` command does not work with compressed help pages.
 
 For more information, read:
 
@@ -1564,15 +1566,15 @@ SECTION 5 - EDITING A FILE ~
 5.1. How do I load a file in Vim for editing?
 
 There are several ways to load a file for editing. The simplest is to
-use the ":e" (:edit) command: >
+use the `:e` (:edit) command: >
 
     :e <filename>
 <
-You can also use the ":n" (:next) command to load files into Vim: >
+You can also use the `:n` (:next) command to load files into Vim: >
 
     :n <filename(s)>
 <
-You can also use the ":args" command to load files into Vim: >
+You can also use the `:args` command to load files into Vim: >
 
     :args <filename(s)>
 <
@@ -1588,7 +1590,7 @@ For more information, read:
 5.2. How do I save the current file in another name (save as) and edit a
      new file?
 
-You can use the ":saveas" command to save the current file in another name: >
+You can use the `:saveas` command to save the current file in another name: >
 
     :saveas <newfilename>
 <
@@ -1597,7 +1599,7 @@ Alternatively, you can also use the following commands: >
     :w <newfilename>
     :edit #
 <
-You can also use the ":file" command, followed by ":w" command: >
+You can also use the `:file` command, followed by `:w` command: >
 
     :file <newfilename>
     :w
@@ -1730,9 +1732,9 @@ For more information, read:
  								*faq-5.8*
 5.8. How do I reload/re-edit the current file?
 
-You can use the ":edit" command, without specifying a file name, to reload
+You can use the `:edit` command, without specifying a file name, to reload
 the current file.  If you have made modifications to the file, you can use
-":edit!" to force the reload of the current file (you will lose your
+`:edit!` to force the reload of the current file (you will lose your
 modifications, but depending on your 'undoreload' settings, those
 changes might be saved into the undo history).
 
@@ -1757,7 +1759,7 @@ For more information, read:
  								*faq-5.10*
 5.10. How do I open a file in read-only mode?
 
-You can open a file in read-only mode using the ":view" command: >
+You can open a file in read-only mode using the `:view` command: >
 
     :view <filename>
 <
@@ -1847,23 +1849,23 @@ different things in VIM.
 
 args is a list of arguments. Buffers are place to edit text, almost
 always attached to a file but not necessarily. Window is a place for a
-buffer and tab is set of windows, better name would be 'layout'.
+buffer and tab is set of windows, better name would be "layout".
 
 There are several ways to open multiple files at once from within Vim. You
-can use the ":next" command to specify a group of files: >
+can use the `:next` command to specify a group of files: >
 
     :next f1.txt f2.txt
     :next *.c
 <
-You can use the :args command to specify a group of files as arguments: >
+You can use the `:args` command to specify a group of files as arguments: >
 
     :args f1.txt f2.txt
     :args *.c
 <
-After loading the files, you can use the ":next" and ":prev" command to
+After loading the files, you can use the `:next` and `:prev` command to
 switch between the files.
 
-To execute command for all files in argument-list use ":argdo"
+To execute command for all files in argument-list use `:argdo`
 
 For more information, read:
 
@@ -1875,33 +1877,33 @@ For more information, read:
  								*faq-6.2*
 6.2. How do I switch between multiple files/buffers in Vim?
 
-To list all buffers use ":ls", to list buffers without file attached to
+To list all buffers use `:ls`, to list buffers without file attached to
 (also known as unlisted buffers, ex. scratch buffer and help-window) use
-":ls!"
+`:ls!`
 
 There are several ways to switch between multiple files. You can use the
-":buffer" command to switch between multiple files. You can also shorten
-command as ":b" and use only part of the filename. For example, >
+`:buffer` command to switch between multiple files. You can also shorten
+command as `:b` and use only part of the filename. For example, >
 
     :buffer file1
     :buffer file2
     :b e2
 <
-You can also use <TAB> after ":b" for autocompletion. Try also ":b"
-followed by <CTRL-d> to see all available buffers. This works also for
-":e".
+You can also use <TAB> after `:b` for autocompletion. Try also `:b`
+followed by CTRL-D to see all available buffers. This works also for
+`:e`.
 
 You can also use the CTRL-^ key to switch between buffers. By specifying a
 count before pressing the key, you can edit the buffer with that number.
 Without the count, you can edit the alternate buffer by pressing CTRL-^
 
-You can also use the ":e #" command to edit a particular buffer: >
+You can also use the `:e #` command to edit a particular buffer: >
 
     :e #5
 <
-To close a buffer use ":bd" -command.
+To close a buffer use `:bd` -command.
 
-To execute command for all files in buffer-list use ":bufdo"
+To execute command for all files in buffer-list use `:bufdo`
 
 For more information, read:
 
@@ -1947,15 +1949,15 @@ For more information, read:
 6.4. How do I configure Vim to autoload several files at once similar to
      "work-sets" or "projects"?
 
-You can use the ":mksession" and the ":mkview" commands to autoload several
+You can use the `:mksession` and the `:mkview` commands to autoload several
 files in Vim.
 
-The ":mksession" command creates a Vim script that restores the current
-editing session. You can use the ":source" command to source the file
+The `:mksession` command creates a Vim script that restores the current
+editing session. You can use the `:source` command to source the file
 produced by the mksession command.
 
-The ":mkview" command creates a Vim script that restores the contents of
-the current window. You can use the ":loadview" command to load the view
+The `:mkview` command creates a Vim script that restores the contents of
+the current window. You can use the `:loadview` command to load the view
 for the current file.
 
 For more information, read:
@@ -2094,10 +2096,10 @@ For more information, read:
      How do I configure Vim to save a file without changing the file
      permissions?
 
-This may happen, if the 'backupcopy' option is set to 'no' or 'auto'. Note
+This may happen, if the 'backupcopy' option is set to "no" or "auto". Note
 that the default value for this option is set in such a way that this will
 correctly work in most of the cases. If the default doesn't work for you,
-try setting the 'backupcopy' option to 'yes' to keep the file permission
+try setting the 'backupcopy' option to "yes" to keep the file permission
 when saving a file: >
 
     :set backupcopy=yes
@@ -2154,7 +2156,7 @@ For more information, read:
  								*faq-8.3*
 8.3. How do I replace the buffer in the current window with a blank buffer?
 
-You can use the ":enew" command to load an empty buffer in place of the
+You can use the `:enew` command to load an empty buffer in place of the
 buffer in the current window.
 
 For more information, read:
@@ -2175,12 +2177,12 @@ For more information, read:
  								*faq-8.5*
 8.5. How do I open all the current buffers in separate windows?
 
-You can use the ":ball" or ":sball" commands to open all the buffers
+You can use the `:ball` or `:sball` commands to open all the buffers
 in the buffer list: >
 
     :ball
 <
-If you want all buffers to be opened in new tabs, simply prefix the :tab
+If you want all buffers to be opened in new tabs, simply prefix the `:tab`
 command: >
 
     :tab :sball
@@ -2192,7 +2194,7 @@ For more information, read:
  								*faq-8.6*
 8.6. How do I close (delete) a buffer without exiting Vim?
 
-You can use any of ":bdelete", ":bwipeout" or ":bunload" commands to
+You can use any of `:bdelete`, `:bwipeout` or `:bunload` commands to
 delete a buffer without exiting Vim. For example: >
 
     :bdelete file1
@@ -2204,13 +2206,13 @@ For more information, read:
     |:bunload|
 
  								*faq-8.7*
-8.7. When I use the command ":%bd" to delete all the buffers, not all the
+8.7. When I use the command `:%bd` to delete all the buffers, not all the
      buffers are deleted. Why?
 
-In the ":%bd" command, the '%' range will be replaced with the starting and
-ending line numbers in the current buffer. Instead of using '%' as the
+In the `:%bd` command, the "%" range will be replaced with the starting and
+ending line numbers in the current buffer. Instead of using "%" as the
 range, you should specify numbers for the range. For example, to delete all
-the buffers, you can use the command ":1,9999bd".
+the buffers, you can use the command `:1,9999bd`.
 
 For more information, read:
 
@@ -2256,10 +2258,10 @@ For more information, read:
     |:buffers|
 
  								*faq-8.10*
-8.10. How do I map the tab key to cycle through and open all the buffers?
+8.10. How do I map the <Tab> key to cycle through and open all the buffers?
 
-You can use the following two map commands, to map the CTRL-Tab key to open
-the next buffer and the CTRL-SHIFT-Tab key to open the previous buffer: >
+You can use the following two map commands, to map the <Ctrl-Tab> key to open
+the next buffer and the <Ctrl-Shift-Tab> key to open the previous buffer: >
 
     :nnoremap <C-Tab> :bnext<CR>
     :nnoremap <S-C-Tab> :bprevious<CR>
@@ -2313,17 +2315,17 @@ For more information, read:
 9.3. How do I zoom into or out of a window?
 
 You can zoom into a window (close all the windows except the current
-window) using the "CTRL-W o" command or the ":only" ex command.
+window) using the "<CTRL-W>o" command or the `:only` ex command.
 
-You can use the "CTRL-W _" command or the ":resize" ex command to increase
+You can use the "<CTRL-W>_" command or the `:resize` ex command to increase
 the current window height to the highest possible without closing other
 windows.
 
-You can use the "CTRL-W |" command or the ":vertical resize" ex command to
+You can use the "<CTRL-W>|" command or the `:vertical resize` ex command to
 increase the current window width to the highest possible without closing
 other windows.
 
-You can use the "CTRL-W =" command to make the height and width of all the
+You can use the "<CTRL-W>=" command to make the height and width of all the
 windows equal.
 
 You can also set the following options to get better results with the above
@@ -2369,11 +2371,11 @@ For more information, read:
 9.4. How do I execute an ex command on all the open buffers or open windows
      or all the files in the argument list?
 
-You can use the ":bufdo" command to execute an ex command on all the open
-buffers.  You can use the ":windo" command to execute an ex command on all
-the open windows.  You can use the ":argdo" command to execute an ex
+You can use the `:bufdo` command to execute an ex command on all the open
+buffers.  You can use the `:windo` command to execute an ex command on all
+the open windows.  You can use the `:argdo` command to execute an ex
 command on all the files specified in the argument list. And finally you
-can use the ":tabdo" command to execute an ex command in all open tab pages.
+can use the `:tabdo` command to execute an ex command in all open tab pages.
 
 For more information, read:
 
@@ -2391,7 +2393,7 @@ SECTION 10 - MOTION ~
 10.1. How do I jump to the beginning (first line) or end (last line) of a
      file?
 
-You can use 'G' command to jump to the last line in the file and the 'gg'
+You can use "G" command to jump to the last line in the file and the "gg"
 command to jump to the first line in the file.
 
 For more information, read:
@@ -2466,7 +2468,7 @@ You can use the following mappings: >
  								*faq-10.5*
 10.5. What is the definition of a sentence, paragraph and section in Vim?
 
-A sentence is defined as ending at a '.', '!' or '?' followed by either the
+A sentence is defined as ending at a ".", "!" or "?" followed by either the
 end of a line, or by a space (or two) or tab. Which characters and the
 number of spaces needed to constitute a sentence ending is determined by
 the 'joinspaces' and 'cpoptions' options.
@@ -2541,7 +2543,7 @@ For more information, read:
  								*faq-10.8*
 10.8. How do I scroll two or more buffers simultaneously?
 
-You can set the "scrollbind" option for each of the buffers to scroll them
+You can set the 'scrollbind' option for each of the buffers to scroll them
 simultaneously.
 
 For more information, read:
@@ -2566,7 +2568,7 @@ with the 'timeoutlen' and 'ttimeoutlen' options, may fix the problem.
 The preceding procedure will not work correctly if your terminal sends key
 codes that Vim does not understand. In this situation, your best option is
 to map your key sequence to a matching cursor movement command and save
-these mappings in a file. You can then ":source" the file whenever you work
+these mappings in a file. You can then `:source` the file whenever you work
 from that terminal.
 
 For more information, read:
@@ -2583,7 +2585,7 @@ For more information, read:
       line, when the left arrow key is pressed and the cursor is currently
       at the beginning of a line?
 
-You can add the '<' flag to the 'whichwrap' option to configure Vim to move
+You can add the "<" flag to the 'whichwrap' option to configure Vim to move
 the cursor to the end of the previous line, when the left arrow key is
 pressed and the cursor is currently at the beginning of a line: >
 
@@ -2591,12 +2593,12 @@ pressed and the cursor is currently at the beginning of a line: >
 <
 Similarly, to move the cursor the beginning of the next line, when the
 right arrow key is  pressed and the cursor is currently at the end of a
-line, add the '>' flag to the 'whichwrap' option: >
+line, add the ">" flag to the 'whichwrap' option: >
 
     :set whichwrap+=>
 <
 The above will work only in normal and visual modes. To use this in insert
-and replace modes, add the '[' and ']' flags respectively.
+and replace modes, add the "[" and "]" flags respectively.
 
 For more information, read:
 
@@ -2624,7 +2626,7 @@ disable this option, reset the 'insertmode' option: >
 You can also start vim using the "evim" command or you can use "vim -y" to
 use Vim as a modeless editor.
 
-You can also start Vim in insert mode using the ":startinsert" ex command.
+You can also start Vim in insert mode using the `:startinsert` ex command.
 
 For more information, read:
 
@@ -2684,14 +2686,13 @@ To temporarily turn off the search highlighting, use >
     :nohlsearch
 <
 You can also clear the search highlighting, by searching for a pattern that
-is not in the current file (for example, search for the pattern 'asdf').
+is not in the current file (for example, search for the pattern "asdf").
 
 You can use this mapping, to clear the search highlighting when
-redrawing the window pressing <CTRL-L> >
+redrawing the window pressing CTRL-L >
 
     :nnoremap <silent> <C-L> <C-L>:nohls<CR>
 <
-
 For more information, read:
 
     |'hlsearch'|
@@ -2700,8 +2701,8 @@ For more information, read:
  								*faq-11.2*
 11.2. How do I enter a carriage return character in a search pattern?
 
-You can either use '\r' or <CTRL-V><CTRL-M> to enter a carriage return
-character in a pattern. In Vim scripts, it is better to use '\r' for the
+You can either use "\r" or <CTRL-V><CTRL-M> to enter a carriage return
+character in a pattern. In Vim scripts, it is better to use "\r" for the
 carriage return character.
 
 For more information, read:
@@ -2725,9 +2726,9 @@ For more information, read:
     |/\r|
 
  								*faq-11.4*
-11.4. How can I search/replace characters that display as '~R', '~S', etc.?
+11.4. How can I search/replace characters that display as "~R", "~S", etc.?
 
-You can use the 'ga' command to display the ASCII value/code for the
+You can use the "ga" command to display the ASCII value/code for the
 special character. For example, let us say the ASCII value is 142. Then you
 can use the following command to search for the special character: >
 
@@ -2820,7 +2821,7 @@ twice consecutively: >
      /\(\<\w\+\)\_s\+\1\>
      /\(\<\k\+\)\_s\+\1\>
 <
-The main difference is the use of '\w' and '\k', where the latter is based
+The main difference is the use of "\w" and "\k", where the latter is based
 on the 'iskeyword' option which may include accented and other language
 specific characters.
 
@@ -2873,7 +2874,7 @@ For more information, read:
 11.11. How do I place the cursor at the end of the matched word when
        searching for a pattern?
 
-You can use the 'e' offset to the search command to place the cursor at the
+You can use the "e" offset to the search command to place the cursor at the
 end of the matched word. For example >
 
     /mypattern/e
@@ -2921,8 +2922,8 @@ For more information, read:
  								*faq-11.14*
 11.14. How do I search and replace a string in multiple files?
 
-You can use the 'argdo', 'bufdo', 'windo' or 'tabdo' commands to execute an
-ex command on multiple files. For example: >
+You can use the `:argdo`, `:bufdo`, `:windo` or `:tabdo` commands to execute
+an ex command on multiple files. For example: >
 
     :argdo %s/foo/bar/g|upd
 <
@@ -2934,12 +2935,12 @@ For more information, read:
     |:tabdo|
 
  								*faq-11.15*
-11.15. I am using the ":s" substitute command in a mapping. When a search
+11.15. I am using the `:s` substitute command in a mapping. When a search
        for a pattern fails, the map terminates. I would like the map to
        continue processing the next command, even if the substitute command
        fails. How do I do this?
 
-You can use the 'e' flag to the substitute command to continue processing
+You can use the "e" flag to the substitute command to continue processing
 other commands in a map, when a pattern is not found.
 
 For more information, read:
@@ -2950,7 +2951,7 @@ For more information, read:
 11.16. How do I search for the n-th occurrence of a character in a line?
 
 To search for the n-th occurrence of a character in a line, you can prefix
-the 'f' command with a number. For example, to search for the 5th
+the "f" command with a number. For example, to search for the 5th
 occurrence of the character @ in a line, you can use the command 5f@. This
 assumes the cursor is at the beginning of the line - and that this first
 character is not the one your are looking for.
@@ -2988,9 +2989,9 @@ For more information, read:
 You can search for a character by its ASCII value by pressing CTRL-V
 followed by the decimal or hexadecimal or octal value of that character in
 the search "/" command.  To determine the ASCII value of a character you
-can use the ":ascii" or the "ga" command.
+can use the `:ascii` or the "ga" command.
 
-For example, to search for the ASCII character with value 188 (??), you can
+For example, to search for the ASCII character with value 188 (¼), you can
 use one of the following search commands: >
 
     /<CTRL-V>188
@@ -3060,7 +3061,7 @@ current buffer that contain "vim": >
 
     :g/vim/p
 <
-Since :p is the default command to be executed for the ex command :g, you
+Since `:p` is the default command to be executed for the ex command `:g`, you
 can also use: >
 
     :g/vim
@@ -3108,7 +3109,7 @@ For more information, read:
 You can search for a pattern within a range of lines using the \%>l
 and \%<l regular expression atoms.
 
-For example, to search for the word 'white' between the lines 10 and 30 in
+For example, to search for the word "white" between the lines 10 and 30 in
 a buffer, you can use the following command: >
 
     /white\%>9l\%<31l
@@ -3138,10 +3139,10 @@ For more information, read:
     |last-pattern|
 
  								*faq-11.24*
-11.24. Why does this pattern 'a.\{-}p\@!' not match?
+11.24. Why does this pattern "a.\{-}p\@!" not match?
 
 "\{-}" doesn't just mean "as few as possible", it means "as few as
-possible to make the whole pattern succeed". If it didn't match the 'p',
+possible to make the whole pattern succeed". If it didn't match the "p",
 the whole pattern would fail (because of the "p\@!") so it does match
 the "p". It is a longer match, but it is the shortest match that makes
 the whole pattern succeed.
@@ -3154,19 +3155,19 @@ when there are not other restrictions. The whole pattern then would
 behave the same as "ap\@!", i.e. it would match any "a" not followed by
 a "p").
 
-This means, it matches as few as possible 'a's without trying to keep
+This means, it matches as few as possible "a"s without trying to keep
 going until Vim finds the longest match. This means, it will still match
-'ap'.
+"ap".
 
  								*faq-11.25*
-11.25. How can I use '/' within a pattern, without escaping it?
+11.25. How can I use "/" within a pattern, without escaping it?
 
-When using / to search for a pattern, you need to escape all '/' within
+When using / to search for a pattern, you need to escape all "/" within
 the pattern, because they would otherwise terminate the pattern. So you
 can't directly search for /usr/share/doc/ but need to search for
 \/usr\/share\/doc\/
 
-The easiest solution around that, would be to use '?' to start a
+The easiest solution around that, would be to use "?" to start a
 backward search and afterwards use /<CR> to use the last search-pattern
 in forward direction.
 
@@ -3176,7 +3177,7 @@ into the search register:
 
 :let @/ = '/usr/share/doc/'
 
-Then use 'n' to jump to the next occurrence.
+Then use "n" to jump to the next occurrence.
 
 See also the help at
 
@@ -3186,22 +3187,22 @@ See also the help at
  								*faq-11.26*
 11.26. How can I operate on a search match?
 
-The 'gn' command makes it easy to operate on regions of text that match
+The "gn" command makes it easy to operate on regions of text that match
 the current search pattern. By default, it will search forward for the
 last used search pattern and visually select the match. If the cursor is
-already on the match, it will be visually selected. If you used the 'gn'
-command after an operator (e.g. 'c' to change text), it will be applied
+already on the match, it will be visually selected. If you used the "gn"
+command after an operator (e.g. "c" to change text), it will be applied
 on the match.
 
 If Visual mode is active before using gn, the visual selection will be
 extended until the end of the next match.
 
-The 'gN' commands works similar but searches backwards.
+The "gN" commands works similar but searches backwards.
 
 This allows to repeat simple operations on each match. For example, you
 might want to change each occurence of apples by peaches. So you search
-using '/apple' then you can use 'cgnpeach<esc>' to replace the current
-match by peach. Now you can use the dot '.' command to redo the
+using "/apple" then you can use "cgnpeach<Esc>" to replace the current
+match by peach. Now you can use the dot "." command to redo the
 replacement for the rest of the buffer.
 
 See also the help at
@@ -3217,7 +3218,7 @@ SECTION 12 - CHANGING TEXT ~
 12.1. How do I delete all the trailing white space characters (SPACE and
       TAB) at the end of all the lines in a file?
 
-You can use the ":substitute" command on the entire file to search and
+You can use the `:substitute` command on the entire file to search and
 remove all the trailing white space characters: >
 
     :%s/\s\+$//
@@ -3324,8 +3325,8 @@ You can specify a motion command with the yank operator (y) to yank text
 from one position to another position within a line. For example, to yank
 from the current cursor position till the next letter x, use yfx or Fx or
 tx or Tx. To yank till the nth column, use n|. To yank till the next
-occurrence of a 'word', use /word. To do a yank till the nth column on
-another line, first mark the position using the 'ma' command, go to the
+occurrence of a "word", use /word. To do a yank till the nth column on
+another line, first mark the position using the "ma" command, go to the
 start of the yank position, and then yank till the mark using y`a (note the
 direction of the quote)
 
@@ -3360,7 +3361,7 @@ use the yank operator followed by a motion command. For example: >
 
         y)
 <
-From inside the sentence you can use 'yi)' to yank the sentence.
+From inside the sentence you can use "yi)" to yank the sentence.
 
 For more information, read:
 
@@ -3372,7 +3373,7 @@ For more information, read:
  								*faq-12.9*
 12.9. How do I yank all the lines containing a pattern into a buffer?
 
-You can use the ":global" command to yank all the lines containing the
+You can use the `:global` command to yank all the lines containing the
 pattern into a register and then paste the contents of the register into
 the buffer: >
 
@@ -3385,9 +3386,9 @@ Note that the capital letter "A" is used to append the matched lines. Now
 you can paste the contents of register "a" to a buffer using "ap command.
 
 If you only want to collect all matches, you can use a different
-approach. For that run the ':s' command with the flags 'gn' so that it
-won't actually  change the buffer ('n' flag) but select each match ('g'
-flag). Combining this with the '\=' part in the replacement part, you
+approach. For that run the `:s` command with the flags "gn" so that it
+won't actually  change the buffer ("n" flag) but select each match ("g"
+flag). Combining this with the "\=" part in the replacement part, you
 can copy each match to e.g. a list. Altogether this looks like this: >
 
     :let list=[]
@@ -3411,7 +3412,7 @@ For more information, read:
 12.10. How do I delete all the lines in a file that do not contain a
        pattern?
 
-You can use ":v" command to delete all the lines that do not contain a
+You can use `:v` command to delete all the lines that do not contain a
 pattern: >
 
     :v/pattern/d
@@ -3449,7 +3450,7 @@ For more information, read:
 12.12. Is there a way to operate on a line if the previous line contains a
        particular pattern?
 
-You can use the ":global" command to operate on a line, if the previous
+You can use the `:global` command to operate on a line, if the previous
 line contains a particular pattern: >
 
     :g/<pattern>/+{cmd}
@@ -3462,18 +3463,18 @@ For more information, read:
  								*faq-12.13*
 12.13. How do I execute a command on all the lines containing a pattern?
 
-You can use the ":global" (:g) command to execute a command on all the
+You can use the `:global` (:g) command to execute a command on all the
 lines containing a pattern. >
 
     :g/my pattern/d
 <
-If you want to use a non-Ex command, then you can use the ":normal"
+If you want to use a non-Ex command, then you can use the `:normal`
 command: >
 
     :g/my pattern/normal {command}
 <
 Unless you want the normal mode commands to be remapped, consider using a
-":normal!" command instead (note the "!").
+`:normal!` command instead (note the "!").
 
 For more information, read:
 
@@ -3486,8 +3487,8 @@ For more information, read:
        position?
 
 In Insert mode, you can copy the character above the cursor to the current
-cursor position by typing <Ctrl-Y>. The same can be done with the
-characters below the cursor by typing <Ctrl-E>.
+cursor position by typing CTRL-Y. The same can be done with the
+characters below the cursor by typing CTRL-E.
 
 For more information, read:
 
@@ -3498,7 +3499,7 @@ For more information, read:
 12.15. How do I insert a blank line above/below the current line without
        entering insert mode?
 
-You can use the ":put" ex command to insert blank lines. For example, try >
+You can use the `:put` ex command to insert blank lines. For example, try >
 
     :put =''
     :put! =''
@@ -3512,7 +3513,7 @@ For more information, read:
 
 There are several ways to insert the name of the current file into the
 current buffer. In insert mode, you can use the <C-R>% or the
-<C-R>=expand("%") command. In normal mode, you can use the ":put =@%"
+<C-R>=expand("%") command. In normal mode, you can use the `:put =@%`
 command.
 
 For more information, read:
@@ -3525,12 +3526,12 @@ For more information, read:
 12.17. How do I insert the contents of a Vim register into the current
        buffer?
 
-In insert mode, you can use the <C-R><register> command to insert the
-contents of <register>. For example, use <C-R>a to insert the contents
+In insert mode, you can use the <CTRL-R><register> command to insert the
+contents of <register>. For example, use <CTRL-R>a to insert the contents
 of register "a" into the current buffer.
 
-In normal mode, you can use the ":put <register>" command to insert the
-contents of <register>. For example, use the ":put d" command to insert
+In normal mode, you can use the `:put <register>` command to insert the
+contents of <register>. For example, use the `:put d` command to insert
 the contents of register "d" into the current buffer.
 
 For more information, read:
@@ -3545,7 +3546,7 @@ For more information, read:
 12.18. How do I move the cursor past the end of line and insert some
        characters at some columns after the end of the line?
 
-You can set the "virtualedit" option to move the cursor past the
+You can set the 'virtualedit' option to move the cursor past the
 end-of-line and insert characters in a column after the end-of-line. To
 start the virtual mode, use >
 
@@ -3580,7 +3581,7 @@ For more information, read:
  								*faq-12.20*
 12.20. How do I replace a particular text in all the files in a directory?
 
-You can use the "argdo" command to execute the substitute command on all
+You can use the `:argdo` command to execute the substitute command on all
 the files specified as arguments: >
 
     :args *
@@ -3610,17 +3611,17 @@ For more information, read:
     |'nrformats'|
 
  								*faq-12.22*
-12.22. How do I reuse the last used search pattern in a ":substitute"
+12.22. How do I reuse the last used search pattern in a `:substitute`
        command?
 
-To reuse the last used search pattern in a ":substitute" command, don't
+To reuse the last used search pattern in a `:substitute` command, don't
 specify a new search pattern: >
 
     :s/pattern/newtext/
     :s//sometext/
 <
-In the second ":s" command, as a search pattern is not specified, the
-pattern specified in the first ":s" command 'pattern' will be used.
+In the second `:s` command, as a search pattern is not specified, the
+pattern specified in the first `:s` command "pattern" will be used.
 
 If you want to change the search pattern but repeat the substitution
 pattern you can use the special right hand side, you can use the tilde
@@ -3637,11 +3638,11 @@ For more information, read:
     |sub-replace-special|
 
  								*faq-12.23*
-12.23. How do I change the case of a string using the ":substitute"
+12.23. How do I change the case of a string using the `:substitute`
        command?
 
 You can use special characters in the replacement string for a
-":substitute" command to change the case of the matched string. For
+`:substitute` command to change the case of the matched string. For
 example, to change the case of the string "MyString" to all uppercase, you
 can use the following command: >
 
@@ -3668,9 +3669,9 @@ For more information, read:
 12.24. How do I enter characters that are not present in the keyboard?
 
 You can use digraphs to enter characters that are not present in the
-keyboard. You can use the ":digraphs" command to display all the currently
+keyboard. You can use the `:digraphs` command to display all the currently
 defined digraphs. You can add a new digraph to the list using the
-":digraphs" command.
+`:digraphs` command.
 
 For more information, read:
 
@@ -3705,7 +3706,7 @@ For more information, read:
        with "+" and wrapped to the next line. How can I quickly join the
        lines?
 
-You can use the ":global" command to search and join the lines: >
+You can use the `:global` command to search and join the lines: >
 
     :g/+$/j
 <
@@ -3724,7 +3725,7 @@ For more information, read:
  								*faq-12.28*
 12.28. How do I paste characterwise yanked text into separate lines?
 
-You can use the ":put" command to paste characterwise yanked text into new
+You can use the `:put` command to paste characterwise yanked text into new
 lines: >
 
     :put =@"
@@ -3785,7 +3786,7 @@ For more information, read:
 12.31. How do I replace non-printable characters in a file?
 
 To replace a non-printable character, you have to first determine the ASCII
-value for the character. You can use the ":ascii" ex command or the "ga"
+value for the character. You can use the `:ascii` ex command or the "ga"
 normal-mode command to display the ASCII value of the character under the
 cursor.
 
@@ -3794,7 +3795,7 @@ the decimal number 1-255 (with no leading zero), or by x and a hex number
 00-FF, or by an octal number 0-0377 (with leading zero), or by u and a hex
 number 0-FFFF, or by U and a hex number 0-7FFFFFFF
 
-Another alternative is to use the ":digraphs" ex command to display the
+Another alternative is to use the `:digraphs` ex command to display the
 digraphs for all characters, together with their value in decimal and
 alpha. You can enter a non-printable character by entering CTRL-K followed
 by two alphanumeric characters (a digraph).
@@ -3814,7 +3815,7 @@ lines from a buffer:
 
 :command -range=% Uniq <line1>,<line2>g/^\%<<line2>l\(.*\)\n\1$/d
 
-Add the above command to your .vimrc file and invoke ":Uniq" to remove all
+Add the above command to your .vimrc file and invoke `:Uniq` to remove all
 the duplicate lines.
 
  								*faq-12.33*
@@ -3839,9 +3840,9 @@ regions, you can also use this idiom: >
     :let i = 1
     :g/TODO/s/^/\=printf('%2d.',i)|let i+=1
 <
-This first initializes the variable i with 1. In the next line, a :g
+This first initializes the variable i with 1. In the next line, a `:g`
 command is used to perform a substitute command only on lines, that
-match 'TODO'. After the substitute command has taken place, the variable
+match "TODO". After the substitute command has taken place, the variable
 i will be incremented by 1.
 
 For more information, read:
@@ -3857,21 +3858,21 @@ For more information, read:
  								*faq-12.34*
 12.34. How do I exchange (swap) two characters or words or lines?
 
-You can exchange two characters with the "xp" command sequence. The 'x'
-will delete the character under the cursor and 'p' will paste the just
+You can exchange two characters with the "xp" command sequence. The "x"
+will delete the character under the cursor and "p" will paste the just
 deleted character after the character under the cursor. This will result
 in exchanging the two characters.
 
 You can exchange two words with the "deep" command sequence (start with the
 cursor in the blank space before the first word).
 
-You can exchange two lines with the "ddp" command sequence. The 'dd' will
-delete the current line and 'p' will paste the just deleted line after the
+You can exchange two lines with the "ddp" command sequence. The "dd" will
+delete the current line and "p" will paste the just deleted line after the
 current line. This will result in exchanging the two lines.
 
 All of the above operations will change the " unnamed register.
 
-You can use the ":m +" ex command to exchange two lines without changing the
+You can use the `:m +` ex command to exchange two lines without changing the
 unnamed register.
 
 For more information, read:
@@ -3891,11 +3892,11 @@ For more information, read:
 Vim uses the characters specified by the 'iskeyword' option as word
 delimiters. The default setting for this option is "@,48-57,_,192-255".
 
-For example, to add ':' as a word delimiter, you can use >
+For example, to add ":" as a word delimiter, you can use >
 
     :set iskeyword+=:
 <
-To remove '_' as a word delimiter, you can use >
+To remove "_" as a word delimiter, you can use >
 
     :set iskeyword-=_
 <
@@ -3975,9 +3976,9 @@ SECTION 14 - TEXT FORMATTING ~
 14.1. How do I format a text paragraph so that a new line is inserted at
       the end of each wrapped line?
 
-You can use the 'gq' command to format a paragraph. This will format the
+You can use the "gq" command to format a paragraph. This will format the
 text according to the current 'textwidth' setting. An alternative would be
-to use the 'gw' command that formats like 'gq' but does not move the
+to use the "gw" command that formats like "gq" but does not move the
 cursor.
 
 Note that the gq operator can be used with a motion command to operate on a
@@ -3998,7 +3999,7 @@ For more information, read:
 
  								*faq-14.2*
 14.2. How do I format long lines in a file so that each line contains less
-      than 'n' characters?
+      than "n" characters?
 
 You can set the 'textwidth' option to control the number of characters that
 can be present in a line. For example, to set the maximum width of a line
@@ -4053,7 +4054,7 @@ into this format:
   - this is a test. this is a test. this is a test. this is a test.
     this is a test.
 
-You can use the 'n' flag in the 'formatoptions' to align the text. >
+You can use the "n" flag in the 'formatoptions' to align the text. >
 
     :set fo+=n
 <
@@ -4104,7 +4105,7 @@ For more information, read:
  								*faq-14.7*
 14.7. How do I increase or decrease the indentation of the current line?
 
-You can use the '>>' and '<<' commands to increase or decrease the
+You can use the ">>" and "<<" commands to increase or decrease the
 indentation of the current line.
 
 For more information, read:
@@ -4152,7 +4153,7 @@ For more information, read:
 
 By default, the automatic indentation of text is not turned on. Check the
 configuration files (.vimrc, .gvimrc) for settings related to indentation.
-Make sure the ":filetype indent on" command is not present. If it is
+Make sure the `:filetype indent on` command is not present. If it is
 present, remove it. Also, depending on your preference, you may also want
 to check the value of the 'autoindent', 'smartindent', 'cindent' and
 'indentexpr' options and turn them off as needed.
@@ -4169,7 +4170,7 @@ For more information, read:
 14.11. How do I configure Vim to automatically set the 'textwidth' option
        to a particular value when I edit mails?
 
-You can use the 'FileType' autocommand to set the 'textwidth' option: >
+You can use the "FileType" autocommand to set the 'textwidth' option: >
 
     autocmd FileType mail set tw=<your_value>
 <
@@ -4197,21 +4198,21 @@ For more information, read:
 
  								*faq-14.13*
 14.13. I am seeing a lot of ^M symbols in my file. I tried setting the
-       'fileformat' option to 'dos' and then 'unix' and then 'mac'. None of
+       'fileformat' option to "dos" and then "unix" and then "mac". None of
        these helped. How can I hide these symbols?
 
 When a file is loaded in Vim, the format of the file is determined as
 below:
 
 - If all the lines end with a new line (<NL>), then the fileformat is
-  'unix'.
+  "unix".
 - If all the lines end with a carriage return (<CR>) followed by a new line
-  (<NL>), then the fileformat is 'dos'.
+  (<NL>), then the fileformat is "dos".
 - If all the lines end with carriage return (<CR>), then the fileformat is
-  'mac'.
+  "mac".
 
 If the file has some lines ending with <CR> and some lines ending with <CR>
-followed by a <NL>, then the fileformat is set to 'unix'.
+followed by a <NL>, then the fileformat is set to "unix".
 
 You can change the format of the current file, by saving it explicitly in
 dos format: >
@@ -4285,7 +4286,7 @@ You can fix this problem in a terminal Vim in several ways:
 
 1. Build Vim with the +mouse and +xterm_clipboard compile-time options.
    The normal or big or huge build of Vim includes these options.  Set
-   the 'mouse' option to either 'a' or include 'i'.  When pasting text
+   the 'mouse' option to either "a" or include "i".  When pasting text
    using the mouse, don't press the Shift key. This will work only if
    Vim can access the X display. For more information, read the
    following Vim help topics:
@@ -4313,7 +4314,7 @@ You can fix this problem in a terminal Vim in several ways:
 
             alias vim='gvim -v'
 <
-    c)  Put the following command in a file named 'vim' and put that
+    c)  Put the following command in a file named "vim" and put that
         file in your ~/bin directory: >
 
             gvim -v "$@"
@@ -4338,7 +4339,7 @@ You can fix this problem in a terminal Vim in several ways:
 
 3. Set the 'paste' option before pasting the text. This option will
    disable the effect of all the indentation related settings. Make
-   sure to turn off this option using ':set nopaste' after pasting the
+   sure to turn off this option using `:set nopaste` after pasting the
    text. Otherwise the Vim indentation feature will not work.  Do not
    permanently set the 'paste' option in your .vimrc file. If you are
    going to repeat these steps often, then you can set the
@@ -4360,12 +4361,12 @@ You can also refer to the following topics in the user manual:
  								*faq-14.15*
 14.15. When there is a very long wrapped line (wrap is "on") and a line
       doesn't fit entirely on the screen it is not displayed at all. There
-      are blank lines beginning with '@' symbol instead of wrapped line. If
-      I scroll the screen to fit the line the '@' symbols disappear and the
+      are blank lines beginning with "@" symbol instead of wrapped line. If
+      I scroll the screen to fit the line the "@" symbols disappear and the
       line is displayed again. What Vim setting control this behavior?
 
-You can set the 'display' option to 'lastline' to display as much as
-possible of the last line in a window instead of displaying the '@'
+You can set the 'display' option to "lastline" to display as much as
+possible of the last line in a window instead of displaying the "@"
 symbols. >
 
     :set display=lastline
@@ -4378,7 +4379,7 @@ For more information, read:
 14.16. How do I convert all the tab characters in a file to space
        characters?
 
-You can use the ":retab" command to update all the tab characters in the
+You can use the `:retab` command to update all the tab characters in the
 current file with the current setting of 'expandtab' and 'tabstop'. For
 example, to convert all the tabs to white spaces, use >
 
@@ -4404,7 +4405,7 @@ word processor: >
     :set textwidth=0
     :set showbreak=>>>
 <
-You can use the 'gk' and 'gj' commands to move one screen line up and down.
+You can use the "gk" and "gj" commands to move one screen line up and down.
 For more information, read:
 
     |'wrap'|
@@ -4417,14 +4418,14 @@ For more information, read:
  								*faq-14.18*
 14.18. How do I join lines without adding or removing any space characters?
 
-By default, when you join lines using the "J" or ":join" command, Vim will
+By default, when you join lines using the "J" or `:join` command, Vim will
 replace the line break, leading white space and trailing white space with a
 single space character. If there are space characters at the end of a line
-or a line starts with the ')' character, then Vim will not add a space
+or a line starts with the ")" character, then Vim will not add a space
 character.
 
 To join lines without adding or removing any space characters, you can use
-the gJ or ":join!" commands.
+the gJ or `:join!` commands.
 
 For more information, read:
 
@@ -4523,7 +4524,7 @@ For more information, read:
       region for further operation?  (or) How do I re-select the last
       selected visual area again?
 
-You can use the 'gv' command to reselect the last selected visual area. You
+You can use the "gv" command to reselect the last selected visual area. You
 can also use the marks '< and '> to jump to the beginning or the end of the
 last selected visual area.
 
@@ -4536,7 +4537,7 @@ For more information, read:
  								*faq-15.7*
 15.7. How do I jump to the beginning/end of a visually selected region?
 
-You can use the 'o' command to jump to the beginning/end of a visually
+You can use the "o" command to jump to the beginning/end of a visually
 selected region.
 
 For more information, read:
@@ -4573,7 +4574,7 @@ For more information, read:
 
 The 'selectmode' option controls whether Select mode will be started when
 selecting a block of text using the mouse. To start Visual mode when
-selecting text using mouse, remove the 'mouse' value from the 'selectmode'
+selecting text using mouse, remove the "mouse" value from the 'selectmode'
 option: >
 
     :set selectmode-=mouse
@@ -4610,8 +4611,8 @@ SECTION 16 - COMMAND-LINE MODE ~
 16.1. How do I use the name of the current file in the command mode or an
       ex command line?
 
-In the command line, the '%' character represents the name of the current
-file. In some commands, you have to use expand("%") to get the filename: >
+In the command line, the "%" character represents the name of the current
+file. In some commands, you have to use `expand("%")` to get the filename: >
 
     :!perl %
 <
@@ -4647,7 +4648,7 @@ For more information, read:
 16.3. How do I switch from Vi mode to Ex mode?
 
 You can use the Q command to switch from Vi mode to Ex mode. To switch from
-Ex mode back to the Vi mode, use the :vi command.
+Ex mode back to the Vi mode, use the `:vi` command.
 
 For more information, read:
 
@@ -4660,19 +4661,19 @@ For more information, read:
 16.4. How do I copy the output from an ex-command into a buffer?
 
 To copy the output from an ex-command into a buffer, you have to first get
-the command output into a register. You can use the ":redir" command to get
+the command output into a register. You can use the `:redir` command to get
 the output into a register. For example, >
 
     :redir @a
     :g/HelloWord/p
     :redir END
 <
-Now the register 'a' will contain the output from the ex command
-"g/HelloWord/p". Now you can paste the contents of the register 'a' into a
+Now the register "a" will contain the output from the ex command
+`:g/HelloWord/p`. Now you can paste the contents of the register "a" into a
 buffer. You can also send or append the output of an ex-command into a file
-using the 'redir' command.
+using the `:redir` command.
 
-You can prefix the ":global" command with ":silent", to avoid having the
+You can prefix the `:global` command with `:silent`, to avoid having the
 lines printed to the screen.
 
 To redirect the output from an ex-command to a file, you can use the
@@ -4688,7 +4689,7 @@ For more information, read:
     |:silent|
 
  								*faq-16.5*
-16.5. When I press the tab key to complete the name of a file in the
+16.5. When I press the <Tab> key to complete the name of a file in the
       command mode, if there are more than one matching file names, then
       Vim completes the first matching file name and displays a list of all
       matching filenames. How do I configure Vim to only display the list
@@ -4696,7 +4697,7 @@ For more information, read:
 
 You can modify the 'wildmode' option to configure the way Vim completes
 filenames in the command mode. In this case, you can set the 'wildmode'
-option to 'list': >
+option to "list": >
 
     :set wildmode=list
 <
@@ -4709,7 +4710,7 @@ For more information, read:
       command line to a buffer?
 
 To copy text from a buffer to the command line, after yanking the text from
-the buffer, use Ctrl-R 0 in the command line to paste the text. You can
+the buffer, use "<CTRL-R>0" in the command line to paste the text. You can
 also yank the text to a specific register and use CTRL-R <register> to
 paste the text to the command line.  You can use CTRL-R CTRL-W to paste the
 word under the cursor in the command line.
@@ -4796,10 +4797,10 @@ For more information, read:
 You can save and restore Vim marks across Vim sessions using the viminfo
 file. To use the viminfo file, make sure the 'viminfo' option is not empty.
 To save and restore Vim marks, the 'viminfo' option should not contain the
-'f' flag or should have a value greater than zero for the 'f' option.
+"f" flag or should have a value greater than zero for the "f" option.
 
 You can also use the viminfo file to synchronize the commandline history
-across different sessions using :wvimfo and :rviminfo commands together
+across different sessions using `:wvimfo` and `:rviminfo` commands together
 with the FocusGained and FocusLost autocommands: >
 
     augroup viminfo
@@ -4873,7 +4874,7 @@ SECTION 19 - OPTIONS ~
  								*faq-19.1*
 19.1. How do I configure Vim in a simple way?
 
-You can use the ":options" command to open the Vim option window: >
+You can use the `:options` command to open the Vim option window: >
 
     :options
 <
@@ -4907,17 +4908,17 @@ Some of the Vim options can have a local or global value. A local value
 applies only to a specific buffer or window. A global value applies to all
 the buffers or windows.
 
-When a Vim option is modified using the ":set" command, both the global and
-local values for the option are changed. You can use the ":setlocal"
-command to modify only the local value for the option and the ":setglobal"
+When a Vim option is modified using the `:set` command, both the global and
+local values for the option are changed. You can use the `:setlocal`
+command to modify only the local value for the option and the `:setglobal`
 command to modify only the global value.
 
-You can use the ":setlocal" command to set an option that will affect only
+You can use the `:setlocal` command to set an option that will affect only
 the current file/buffer: >
 
     :setlocal textwidth=70
 <
-Note that not all options can have a local value. You can use ":setlocal"
+Note that not all options can have a local value. You can use `:setlocal`
 command to set an option locally to a buffer/window only if the option is
 allowed to have a local value.
 
@@ -4981,7 +4982,7 @@ For more information, read:
 
  								*faq-19.7*
 19.7. How do I change the width of the line numbers displayed using the
-      "number" option?
+      'number' option?
 
 You can set the minimum number of columns to be used for line numbering by
 setting the 'numberwidth' option: >
@@ -5012,12 +5013,12 @@ reset the 'list' option: >
     (or)
     :set list!
 <
-The ":set list!" command will toggle the current setting of the boolean
+The `:set list!` command will toggle the current setting of the boolean
 'list' option.
 
 You can modify the 'listchars' option to configure how and which invisible
 characters are displayed. For example, with the following command all the
-trailing space characters will be displayed with a '.' character. >
+trailing space characters will be displayed with a "." character. >
 
     :set listchars=trail:.
 <
@@ -5095,7 +5096,7 @@ For more information, read:
        invocations/instances/sessions?
 
 To make a Vim option setting persistent across different Vim instances, add
-your setting to the .vimrc or .gvimrc file. You can also use the ":mkvimrc"
+your setting to the .vimrc or .gvimrc file. You can also use the `:mkvimrc`
 command to generate a vimrc file for the current settings.
 
 For more information, read:
@@ -5122,7 +5123,7 @@ If the mapping sequence is completed before a given timeout period, the
 mapping for that sequence of keys is applied. If you interrupt the mapping,
 the normal actions associated with the keys are executed.
 
-For example, if you have a mapping defined as ":imap vvv Vim is great!!"
+For example, if you have a mapping defined as `:imap vvv Vim is great!!`
 and you type "vvv" quickly, the "Vim is great!!" will be inserted into your
 text. But if you type "vv v" then that is what will put into your text.
 This is also true if you type "vvv" too slowly where "too slowly" is longer
@@ -5135,10 +5136,10 @@ For more information, read:
     |'ttimeout'|
 
  								*faq-19.16*
-19.16. How do I make the 'c' and 's' commands display a '$' instead of
+19.16. How do I make the "c" and "s" commands display a "$" instead of
        deleting the characters I'm changing?
 
-To make the 'c' and 's' commands display a '$' instead of deleting the
+To make the "c" and "s" commands display a "$" instead of deleting the
 characters, add the $ flag to the 'cpoptions' option: >
 
     :set cpoptions+=$
@@ -5148,18 +5149,18 @@ For more information, read:
     |'cpoptions'|
 
  								*faq-19.17*
-19.17. How do I remove more than one flag using a single ":set" command
+19.17. How do I remove more than one flag using a single `:set` command
        from a Vim option?
 
-You can remove more than one flag from a Vim option using a single ":set"
+You can remove more than one flag from a Vim option using a single `:set`
 command, by specifying the flags in exactly the same order as they appear
 in the option. For example, if you use the following command to remove the
-'t' and 'n' flags from the 'formatoptions' option: >
+"t" and "n" flags from the 'formatoptions' option: >
 
     :set formatoptions-=tn
 <
-The 't' and 'n' flags will be removed from the 'formatoptions' option, only
-if the 'formatoptions' option contains these flags in this order: 'tn'.
+The "t" and "n" flags will be removed from the 'formatoptions' option, only
+if the 'formatoptions' option contains these flags in this order: "tn".
 Otherwise, it will not remove the flags. To avoid this problem, you can
 remove the flags one by one: >
 
@@ -5182,9 +5183,9 @@ To see what a key is mapped to, use the following commands: >
     :map! <key>
 <
 You can also check the mappings in a particular mode using one of the
-":cmap", ":nmap", ":vmap", ":imap", ":omap", etc commands.
+`:cmap`, `:nmap`, `:vmap`, `:imap`, `:omap`, etc commands.
 
-To find out, where the key has been mapped, prefix the :verbose command: >
+To find out, where the key has been mapped, prefix the `:verbose` command: >
 
     :verbose :map <key>
 <
@@ -5207,14 +5208,20 @@ For more information, read:
  								*faq-20.3*
 20.3. How do I unmap a previously mapped key?
 
-You can unmap a previously mapped key using the ":unmap" command: >
+You can unmap a previously mapped key using the `:unmap` command: >
 
     :unmap <key>
     :unmap! <key>
 <
-For mode specific mappings, you can use one of the
-":nunmap/:vunmap/:ounmap/:iunmap/:lunmap/:cunmap" commands.
+For mode specific mappings, you can use one of the these commands: >
 
+    :nunmap
+    :vunmap
+    :ounmap
+    :iunmap
+    :lunmap
+    :cunmap
+<
 The following command will fail to unmap a buffer-local mapped key: >
 
     :unmap <key>
@@ -5236,8 +5243,8 @@ For more information, read:
 20.4. I am not able to create a mapping for the <xxx> key. What is wrong?
 
 1) First make sure, the key is passed correctly to Vim. To determine if
-   this is the case, put Vim in Insert mode and then hit Ctrl-V (or
-   Ctrl-Q if your Ctrl-V is remapped to the paste operation (e.g. on
+   this is the case, put Vim in Insert mode and then hit CTRL-V (or
+   CTRL-Q if your CTRL-V is remapped to the paste operation (e.g. on
    Windows if you are using the mswin.vim script file) followed by your
    key.
 
@@ -5248,12 +5255,12 @@ For more information, read:
    using GVim, which should recognise the key correctly.
 
 2) Possibly, Vim gets your key, but sees it as no different than
-   something else. Say you want to map Ctrl-Right, then in Insert mode
-   hit Ctrl-K followed by Ctrl-Right. If Vim displays <C-Right> it has
+   something else. Say you want to map <Ctrl-Right>, then in Insert mode
+   hit CTRL-K followed by <Ctrl-Right>. If Vim displays <C-Right> it has
    correctly seen the keystroke and you should be able to map it (by
    using <C-Right> as your {lhs}). If it displays <Right> it has seen
-   the keystroke but as if you hadn't held Ctrl down: this means your
-   temrinal passes Ctrl-Right as if it were just <Right>. Anything else
+   the keystroke but as if you hadn't held <Ctrl> down: this means your
+   temrinal passes <Ctrl-Right> as if it were just <Right>. Anything else
    means the key has been misidentified.
 
 3) If the key is seen, but not as itself and not as some recognizable
@@ -5272,9 +5279,9 @@ For more information, read:
 <
    where <termname> above should be replaced by the value of 'term'
    (with quotes around it) and <keycode> by what you get when hitting
-   Ctrl-V followed by Ctrl-Right in Insert mode (with nothing around
+   CTRL-V followed by <Ctrl-Right> in Insert mode (with nothing around
    it). <C-Right> should be left as-is (9 characters). Don't forget that
-   in a :set command, white space is not allowed between the equal sign
+   in a `:set` command, white space is not allowed between the equal sign
    and the value, and any space, double quote, vertical bar or backslash
    present as part of the value must be backslash-escaped.
 
@@ -5292,59 +5299,38 @@ For more information, read:
  								*faq-20.5*
 20.5. Why does mapping the <C-...> key not work?
 
-The only Ctrl-printable-key chords which Vim can reliably detect (because they
-are defined in the ASCII standard) are the following: >
+The only <Ctrl>-<printable-key> chords which Vim can reliably detect
+(because they are defined in the ASCII standard) are the following: >
 
-        Ctrl-@                 0x00            NUL
-        Ctrl-A to Ctrl-Z       0x01 to 0x1A
-        Ctrl-a to Ctrl-z       0x01 to 0x1A
-        Ctrl-[                 0x1B            ESC
-        Ctrl-\                 0x1C
-        Ctrl-]                 0x1D
-        Ctrl-^                 0x1E
-        Ctrl-_                 0x1F
-        Ctrl-?                 0x7F            DEL
+        CTRL-@                 0x00            NUL
+        CTRL-A to CTRL-Z       0x01 to 0x1A
+        CTRL-a to CTRL-z       0x01 to 0x1A
+        CTRL-[                 0x1B            ESC
+        CTRL-\                 0x1C
+        CTRL-]                 0x1D
+        CTRL-^                 0x1E
+        CTRL-_                 0x1F
+        CTRL-?                 0x7F            DEL
 <
 Most of these, however, already have a function in Vim (and some are
-aliases of other keys: Ctrl-H and Bsp, Ctrl-I and Tab, Ctrl-M and Enter,
-Ctrl-[ and Esc, Ctrl-? and Del).
+aliases of other keys: CTRL-H and <BS>, CTRL-I and <Tab>, CTRL-M and <Enter>,
+CTRL-[ and <Esc>, CTRL-? and <Del>).
 
 The "safest" keys to use in Vim for the {lhs} of a mapping are the F
 keys, with or without Shift: <F2> to <F12> and <S-F1> to <S-F12>. (Some
-OSes, including mine, intercept Ctrl-Fn and Alt-Fn, which never reach an
+OSes, including mine, intercept <Ctrl-Fn> and <Alt-Fn>, which never reach an
 application program such as vim or gvim).
 
-You can try other combinations of Ctrl + any key, but they may either
+You can try other combinations of <Ctrl> + any key, but they may either
 not work everywhere (e.g. the terminal might not pass that key to Vim,
 or they might have unintended side effects (e.g. mapping <C-I> means
 also to map <Tab>).
 
-If you are using a recent xterm as terminal, Vim is able to actually
-distinguish most Ctrl,Alt,Shift (and even distinguish Ctrl-I from Tab, etc)
-mappings by making use of the modifyOtherKeys feature of xterm. See the xterm
-documentation:
+This is a known issue, that has been discussed and might be implemented
+in the future to enable Vim to distinguish between various keys even in
+console mode. (e.g.
+https://groups.google.com/d/msg/vim_dev/2bp9UdfZ63M/sajb9KM0pNYJ)
 
-https://invisible-island.net/xterm/modified-keys.html
-and
-https://invisible-island.net/xterm/manpage/xterm.html#VT100-Widget-Resources:modifyOtherKeys
-
-For terminals that pretend to be xterm, vim will try to enable this feature.
-You can check, if this feature is enabled in your Vim by typing CTRL-SHIFT-V
-CTRL-V in insert mode. If the result is a single byte, then the feature is
-off, when the feature is enabled, Vim will print: <1b>27;5;118~.
-Note: that your desktop environment or terminal might intercept the key press,
-to e.g. paste the clipboard
-
-If this feature causes problems, you can disable it:
-        let &t_TI = ''
-        let &t_TE = ''
-It does not take effect immediate, run a shell command after changing those
-values: 
-        :!true
-
-For more information, read:
-
-    |modifyOtherKeys|
  								*faq-20.6*
 20.6. How do I map the numeric keypad keys?
 
@@ -5366,7 +5352,7 @@ For more information, read:
 
 You can create mappings that work only in specific modes (normal, command,
 insert, visual, etc). To create a mapping that works only in the visual
-mode, use the ":vmap" command: >
+mode, use the `:vmap` command: >
 
     :vmap <F3> <your mapping here>
 <
@@ -5393,15 +5379,15 @@ For more information, read:
 20.8. How do I create a mapping that works only in normal and operator
    pending mode (but not in visual mode)?
 
-Using ":map" creates a mapping that works in normal, visual+select mode and
-operator pending mode. You can use ":nmap" to have the mapping only work in
-normal mode and ":vmap" to have the mapping only be defined for visual and
-select mode or use ":omap" to have the mapping only defined in operator
+Using `:map` creates a mapping that works in normal, visual+select mode and
+operator pending mode. You can use `:nmap` to have the mapping only work in
+normal mode and `:vmap` to have the mapping only be defined for visual and
+select mode or use `:omap` to have the mapping only defined in operator
 pending mode.
 
 But if you want to have a mapping defined, that works in both operator
 pending mode and normal mode, but not in visual and select mode, you need
-to first define the mapping using ":map" and afterwards delete the mapping
+to first define the mapping using `:map` and afterwards delete the mapping
 for visual and select mode:
 
 	:map <f3> <your mapping here>
@@ -5431,7 +5417,7 @@ variable to be whatever they wanted: >
     :let mapleader = ","
 <
 When writing a plugin or other script, more often than not, it is advisable
-to use :noremap instead of :map to avoid side effects from user defined
+to use `:noremap` instead of `:map` to avoid side effects from user defined
 mappings.
 
 For more information, read:
@@ -5443,7 +5429,7 @@ For more information, read:
  								*faq-20.10*
 20.10. How do I map the escape key?
 
-You can map the Escape key to some other key using the ":map" command. For
+You can map the Escape key to some other key using the `:map` command. For
 example, the following command maps the escape key to CTRL-O. >
 
     :map <C-O> <Esc>
@@ -5466,7 +5452,7 @@ For more information, read:
     |map-modes|
 
  								*faq-20.12*
-20.12. I want to use the Tab key to indent a block of text and Shift-Tab
+20.12. I want to use the <Tab> key to indent a block of text and <Shift-Tab>
        key to unindent a block of text. How do I map the keys to do this?
        This behavior is similar to textpad, visual studio, etc.
 
@@ -5500,8 +5486,8 @@ Check the value of the 'cpoptions' option: >
 
     :set cpoptions?
 <
-If this option contains the '<' flag, then special characters will not be
-recognized in mappings. Remove the '<' flag from 'cpoptions' option: >
+If this option contains the "<" flag, then special characters will not be
+recognized in mappings. Remove the "<" flag from 'cpoptions' option: >
 
     :set cpo-=<
 <
@@ -5519,9 +5505,9 @@ For more information, read:
     |'compatible'|
 
  								*faq-20.14*
-20.14. How do I use the '|' to separate multiple commands in a map?
+20.14. How do I use the "|" to separate multiple commands in a map?
 
-You can escape the '|' character using backslash (\) to use '|' in a map. >
+You can escape the "|" character using backslash (\) to use "|" in a map. >
 
     :map _l :!ls \| more<CR>
 <
@@ -5540,7 +5526,7 @@ For more information, read:
        another mapping/abbreviation, how do I keep the first from expanding
        into the second one?
 
-Instead of using the ":map lhs rhs" command, use the ":noremap lhs rhs"
+Instead of using the `:map lhs rhs` command, use the `:noremap lhs rhs`
 command. For abbreviations, use "noreabbrev lhs rhs". The "nore" prefix
 prevents the mapping or abbreviation from being expanded again.
 
@@ -5582,7 +5568,7 @@ For more information, read:
 20.17. How do I map a key to run an external command using a visually
        selected text?
 
-You can the ":vmap" command to map a key in the visual mode. In the mapped
+You can the `:vmap` command to map a key in the visual mode. In the mapped
 command sequence, you have to first yank the text. The yanked text is
 available in the '"' register. Now, you can use the contents of this
 register to run the external command. For example, to run the external
@@ -5612,13 +5598,13 @@ For more information, read:
     |:!cmd|
 
  								*faq-20.18*
-20.18. How do I map the Ctrl-I key while still retaining the functionality
+20.18. How do I map the CTRL-I key while still retaining the functionality
        of the <Tab> key?
 
-The Ctrl-I key and the <Tab> key produce the same keycode, so Vim cannot
-distinguish between the Ctrl-I and the <Tab> key. When you map the Ctrl-I
+The CTRL-I key and the <Tab> key produce the same keycode, so Vim cannot
+distinguish between the CTRL-I and the <Tab> key. When you map the CTRL-I
 key, the <Tab> key is also mapped (and vice versa). The same restriction
-applies for the Ctrl-[ key and the <Esc> key.
+applies for the CTRL-[ key and the <Esc> key.
 
 For more information, read:
 
@@ -5631,7 +5617,7 @@ Use the @= command to use an expression. For example, >
 
     nnoremap = @='3l'
 <
-Now you can specify a count to the '=' command.
+Now you can specify a count to the "=" command.
 
     |complex-repeat|
 
@@ -5639,7 +5625,7 @@ Now you can specify a count to the '=' command.
 20.20. How can I make my normal mode mapping work from within Insert
        Mode?
 
-Mappings in normal mode can be executed after <Ctrl-O> from insert mode as
+Mappings in normal mode can be executed after CTRL-O from insert mode as
 well but if there are more commands included in the mapping {rhs}, only the
 first one will be executed in normal mode and the rest of {rhs} will be
 printed literally in insert mode. One of ways to workaround this problem is
@@ -5656,17 +5642,17 @@ A more technical and detailed solution to this problem follows and can
 be found at https://groups.google.com/group/vim_dev/msg/75f1f2dfc00908bb
 
 Not every normal mode-mapping is automatically suitable for execution via
-<Ctrl-O> from within insert mode; you need to explicitly design your mappings
+CTRL-O from within insert mode; you need to explicitly design your mappings
 for that purpose.
 
-The <Ctrl-O> command allows execution of one normal mode command from
+The CTRL-O command allows execution of one normal mode command from
 within insert mode, then returns to insert mode. If a normal mode mapping
 concatenates multiple normal mode commands, this breaks down in temporary
 normal mode and literally inserts the second part of the command into the
 buffer instead. To support execution of normal mode mappings from within
 insert mode, these strategies can be used:
 
-1) Instead of concatenating multiple normal mode commands, use one :normal
+1) Instead of concatenating multiple normal mode commands, use one `:normal`
     mapping: >
 
     :nnoremap <silent> zC :<C-U>normal! zCVzC<CR>
@@ -5683,7 +5669,7 @@ insert mode, these strategies can be used:
     :nnoremap <silent> <script> zC <SID>MyMap1<SID>MyMap2
 <
 4) Normal mode mappings that consist of multiple Ex command lines (and
-    where Ex commands cannot be concatenated via <Bar>) replace ':<C-U>'
+    where Ex commands cannot be concatenated via <Bar>) replace `:<C-U>`
     with <SID>NM; the <SID>NM mapping enters normal mode for one ex command
     line: >
 
@@ -5692,7 +5678,7 @@ insert mode, these strategies can be used:
     :nnoremap <silent> <script> zC <SID>MyMap1<SID>NMcall MyMap2()<CR>
 <
 5)  If none of the above is possible, at least force normal mode for
-    subsequent commands via <CTRL-\><CTRL-N> to avoid accidental insertion
+    subsequent commands via CTRL-\ CTRL-N to avoid accidental insertion
     of the remainder of the mapping. >
 
     :nnoremap zC zC<C-\><C-N>VzCzz
@@ -5763,7 +5749,7 @@ Another alternative is to use the following function and command: >
     command! -nargs=+ Iabbr execute "iabbr" <q-args> . "<C-R>=Eatchar('\\s')<CR>"
 <
 Now, define your abbreviations using the new "Iabbr" command instead of the
-builtin "iabbrev" command. With this command, after expanding the
+builtin `:iabbrev` command. With this command, after expanding the
 abbreviated text, the next typed space character will be discarded.
 
 For more information, read:
@@ -5812,7 +5798,7 @@ SECTION 22 - RECORD AND PLAYBACK ~
 22.1. How do I repeat an editing operation (insertion, deletion, paste,
       etc)?
 
-You can repeat the last editing operation using the '.' command. This will
+You can repeat the last editing operation using the "." command. This will
 repeat the last simple change like a insert, delete, change, paste, etc.
 
 For more information, read:
@@ -5824,7 +5810,7 @@ For more information, read:
  								*faq-22.2*
 22.2. How I record and repeat a set of key sequences?
 
-You can use the 'q' command in normal mode to record a set of key sequences
+You can use the "q" command in normal mode to record a set of key sequences
 and store it in a register. For example, in the normal mode you can press q
 followed by a register name {0-9a-bA-Z"} to start the recording.  To
 end/stop the recording press q again. You can playback/repeat the recorded
@@ -5852,7 +5838,7 @@ For more information, read:
 
 The recorded key sequences are stored in a register. You can paste the
 contents of the register into a Vim buffer, edit the pasted text and again
-yank the text into the register. You can also use the ":let" command to
+yank the text into the register. You can also use the `:let` command to
 modify the register. For example: >
 
     :let @a = "iHello World\<Esc>"
@@ -5873,7 +5859,7 @@ contents of the register into a Vim buffer. Now you can save the buffer
 into a file. You can also modify the pasted text and again yank into the
 register to modify the recorded key sequence. For example, if you record a
 set of key sequences using qa ..... q. The recorded key sequences are
-stored in the register 'a'. You can paste the contents of register 'a'
+stored in the register "a". You can paste the contents of register "a"
 using "ap.
 
 For more information, read:
@@ -6037,7 +6023,7 @@ For more information, read:
  								*faq-24.3*
 24.3. How do I change the highlight colors to suit a dark/light background?
 
-You can set the 'background' option to either 'dark' or 'light' to change
+You can set the 'background' option to either "dark" or "light" to change
 the highlight colors to suit a dark/light background: >
 
     :set background=dark
@@ -6049,7 +6035,7 @@ For more information, read:
 
  								*faq-24.4*
 24.4. How do I change the color of the line numbers displayed when the
-      ":set number" command is used?
+      `:set number` command is used?
 
 The line numbers displayed use the LineNr highlighting group. To display
 the current colors used, use >
@@ -6070,7 +6056,7 @@ For more information, read:
 24.5. How do I change the background color used for a Visually selected
       block?
 
-You can modify the 'Visual' highlight group to change the color used for a
+You can modify the "Visual" highlight group to change the color used for a
 visually selected block: >
 
     :highlight Visual guibg=red
@@ -6091,7 +6077,7 @@ the special characters displayed by the 'list' option: >
     :highlight SpecialKey guibg=green
 <
 The "NonText" highlighting group is used for "eol", "extends" and
-"precedes" settings in the "listchars" option.  The "SpecialKey"
+"precedes" settings in the 'listchars' option.  The "SpecialKey"
 highlighting group is used for the "tab" and "trail" settings.
 
 For more information, read:
@@ -6104,7 +6090,7 @@ For more information, read:
 24.7. How do I specify a colorscheme in my .vimrc/.gvimrc file, so that Vim
       uses the specified colorscheme every time?
 
-You can specify the color scheme using the ":colorscheme" command in your
+You can specify the color scheme using the `:colorscheme` command in your
 .vimrc or .gvimrc file: >
 
     colorscheme evening
@@ -6205,7 +6191,7 @@ For more information, read:
  								*faq-24.13*
 24.13. How do I highlight all the characters after a particular column?
 
-You can use the ":match" command to highlight all the characters after a
+You can use the `:match` command to highlight all the characters after a
 particular column: >
 
     :match Todo '\%>75v.\+'
@@ -6246,7 +6232,7 @@ For more information, read:
 24.15. How do I list the definition of all the current highlight groups?
 
 You can list the definition of all the current highlight groups using the
-":highlight" (without any arguments) ex command.
+`:highlight` (without any arguments) ex command.
 
 For more information, read:
 
@@ -6278,7 +6264,7 @@ SECTION 25 - VIM SCRIPT WRITING ~
  								*faq-25.1*
 25.1. How do I list the names of all the scripts sourced by Vim?
 
-You can use the ":scriptnames" command to list the names of all the scripts
+You can use the `:scriptnames` command to list the names of all the scripts
 sourced by Vim: >
 
     :scriptnames
@@ -6302,7 +6288,7 @@ For more information, read:
  								*faq-25.3*
 25.3. How do I locate the script/plugin which sets a Vim option?
 
-You can use the ":verbose" command to locate the plugin/script which last
+You can use the `:verbose` command to locate the plugin/script which last
 modified a Vim option. For example: >
 
     :verbose set textwidth?
@@ -6317,7 +6303,7 @@ For more information, read:
       when running a script), the messages are cleared immediately. How do
       I display the messages again?
 
-You can use the ":messages" command to display the previous messages. >
+You can use the `:messages` command to display the previous messages. >
 
     :messages
 <
@@ -6334,7 +6320,7 @@ For more information, read:
 
 Vim will save and restore global variables that start with an uppercase
 letter and don't contain a lower case letter. For this to work, the
-'viminfo' option must contain the '!' flag. Vim will store the variables in
+'viminfo' option must contain the "!" flag. Vim will store the variables in
 the viminfo file.
 
 For more information, read:
@@ -6346,7 +6332,7 @@ For more information, read:
  								*faq-25.6*
 25.6. How do I start insert mode from a Vim function?
 
-You can use the ":startinsert" command to start the insert mode from inside
+You can use the `:startinsert` command to start the insert mode from inside
 a Vim function.
 
 For more information, read:
@@ -6388,7 +6374,7 @@ For more information, read:
 25.8. How do I check the value of an environment variable in the .vimrc
       file?
 
-You can use prefix the environment variable name with the '$' character to
+You can use prefix the environment variable name with the "$" character to
 use it from a Vim script/function.  You can refer to the value of an
 environment variable using the $env_var syntax: >
 
@@ -6417,15 +6403,15 @@ For more information, read:
  								*faq-25.10*
 25.10. How do I call/use the Vim built-in functions?
 
-You can use the ":call" command to invoke a Vim built-in function: >
+You can use the `:call` command to invoke a Vim built-in function: >
 
     :call cursor(10,20)
 <
-You can use the ":echo" command to echo the value returned by a function: >
+You can use the `:echo` command to echo the value returned by a function: >
 
     :echo char2nr('a')
 <
-You can use the ":let" command to assign the value returned by a function
+You can use the `:let` command to assign the value returned by a function
 to a variable: >
 
     :let a = getline('.')
@@ -6435,8 +6421,8 @@ the following command: >
 
     :let @a = system('ls')
 <
-The above command will store the output of the 'ls' command into
-the register 'a'.
+The above command will store the output of the "ls" command into
+the register "a".
 
 For more information, read:
 
@@ -6453,7 +6439,7 @@ For more information, read:
        and use the standard Vim functionality for these normal mode
        commands?
 
-You can use the "normal!" command in your script to invoke a normal-mode
+You can use the `:normal!` command in your script to invoke a normal-mode
 command. This will use the standard functionality of the normal mode
 command and will not use the user-defined mapping.
 
@@ -6481,7 +6467,7 @@ You can also use the command: >
 <
 In the above command, gv reselects the last visually selected text and the
 rest of the command copies the selected text into the * (clipboard)
-register. Alternatively, you can set the 'a' flag in the 'guioptions'
+register. Alternatively, you can set the "a" flag in the 'guioptions'
 option to automatically copy a visually selected text into the * register.
 To do this as part of a visual map, you can use a command similar to the
 one shown below: >
@@ -6499,11 +6485,11 @@ For more information, read:
     |registers|
 
  								*faq-25.13*
-25.13. I have some text in a Vim variable 'myvar'. I would like to use this
-       variable in a ":s" substitute command to replace a text 'mytext'.
+25.13. I have some text in a Vim variable "myvar". I would like to use this
+       variable in a `:s` substitute command to replace a text "mytext".
        How do I do this?
 
-You can use the 'execute' command to evaluate the variable: >
+You can use the `:execute` command to evaluate the variable: >
 
     :execute '%s/mytext/' . myvar . '/'
 <
@@ -6523,8 +6509,8 @@ For more information, read:
 25.14. A Vim variable (bno) contains a buffer number. How do I use this
        variable to open the corresponding buffer?
 
-The :buffer command will not accept a variable name. It accepts only a
-buffer number or buffer name. You have to use the ":execute" command to
+The `:buffer` command will not accept a variable name. It accepts only a
+buffer number or buffer name. You have to use the `:execute` command to
 evaluate the variable into the corresponding value. For example: >
 
     :execute "buffer " . bno
@@ -6536,8 +6522,8 @@ For more information, read:
  								*faq-25.15*
 25.15. How do I store the value of a Vim option into a Vim variable?
 
-You can prefix the option name with the '&' character and assign the option
-value to a Vim variable using the "let" command. For example, to store the
+You can prefix the option name with the "&" character and assign the option
+value to a Vim variable using the `:let` command. For example, to store the
 value of the 'textwidth' option into the Vim variable "old_tw", you can use
 the following command: >
 
@@ -6551,7 +6537,7 @@ If you want to explicitly select the global option, use the "g:" prefix to
 the option name.
 
 To do the opposite, to set the 'textwidth' option with the value stored in
-the 'old_tw' variable, you can use the following command: >
+the "old_tw" variable, you can use the following command: >
 
     :let &tw = old_tw
 <
@@ -6627,7 +6613,7 @@ For more information, read:
  								*faq-25.19*
 25.19. How do I get the basename of the current file?
 
-You can use the :t filename modifier to get the basename of the current
+You can use the ":t" filename modifier to get the basename of the current
 file: >
 
     :echo expand("%:t")
@@ -6671,7 +6657,7 @@ For more information, read:
     |10.9|
 
  								*faq-25.22*
-25.22. How do I get the return status of a program executed using the ":!"
+25.22. How do I get the return status of a program executed using the `:!`
        command?
 
 You can use the predefined Vim v:shell_error variable to get the return
@@ -6704,7 +6690,7 @@ For more information, read:
        command from a Vim script. How do I specify the carriage return
        character?
 
-You can use the ":execute" command to specify the special (control)
+You can use the `:execute` command to specify the special (control)
 character in a normal mode command: >
 
     :execute "normal \<CR>"
@@ -6733,19 +6719,19 @@ For more information, read:
     |line-continuation|
 
  								*faq-25.26*
-25.26. When I try to "execute" my function using the "execute Myfunc()"
+25.26. When I try to "execute" my function using the `:execute Myfunc()`
        command, the cursor is moved to the top of the current buffer.
        Why?
 
-The ":execute" command runs the ex command specified by the argument.
+The `:execute` command runs the ex command specified by the argument.
 In the case of the following command: >
 
     :execute Myfunc()
 <
-The call to Myfunc() will return 0. The ":execute" command will run
-the ex command ":0", which moves the cursor to the top of the file.
-To call a Vim function, you should use the ":call" command instead of the
-":execute" command: >
+The call to Myfunc() will return 0. The `:execute` command will run
+the ex command `:0`, which moves the cursor to the top of the file.
+To call a Vim function, you should use the `:call` command instead of the
+`:execute` command: >
 
     :call Myfunc()
 <
@@ -6763,7 +6749,7 @@ For more information, read:
 25.27. How do I source/execute the contents of a register?
 
 If you have yanked a set of Vim commands into a Vim register (for example
-register 'a'), then you can source the contents of the register using one
+register "a"), then you can source the contents of the register using one
 of the following commands:
 
     :@a
@@ -6775,13 +6761,13 @@ For more information, read:
     |:@|
 
  								*faq-25.28*
-25.28. After calling a Vim function or a mapping, when I press the 'u'
+25.28. After calling a Vim function or a mapping, when I press the "u"
        key to undo the last change, Vim undoes all the changes made by
        the mapping/function. Why?
 
 When you call a function or a mapping, all the operations performed by the
 function/mapping are treated as one single operation. When you undo the
-last operation by pressing 'u', all the changes made by the
+last operation by pressing "u", all the changes made by the
 function/mapping are reversed.
 
 For more information, read:
@@ -6830,7 +6816,7 @@ types of files. You should first enable filetype plugins using the command: >
 <
 A filetype plugin is a vim script that is loaded whenever Vim opens or
 creates a file of that type.  For example, to ensure that the 'textwidth'
-option is set to 80 when editing a C program (filetype 'c'), create one of
+option is set to 80 when editing a C program (filetype "c"), create one of
 the following files: >
 
         ~/.vim/ftplugin/c.vim (Unix)
@@ -7022,7 +7008,7 @@ For more information, read:
 
 You can set the 'filetype' option for files with names matching a
 particular pattern using an autocmd. For example, to set the 'filetype'
-option to 'c' for all files with extension '.x', you can use the following
+option to "c" for all files with extension ".x", you can use the following
 autocmd: >
 
     autocmd! BufRead,BufNewFile *.x     setfiletype c
@@ -7144,7 +7130,7 @@ For more information, read:
 27.6. I am editing a C program using Vim. How do I jump to the beginning or
       end of a code block from within the block?
 
-You can use '[{' command to jump to the beginning of the code block and ']}
+You can use "[{" command to jump to the beginning of the code block and "]}"
 to jump to the end of the code block from inside the block.
 
 For more information, read:
@@ -7160,22 +7146,22 @@ For more information, read:
 
 This automatic insertion of the comment leader (//) when new lines
 are added is controlled by three flags in the 'formatoptions'
-option:  'c', 'r' and 'o'.  'c' enables auto-wrapping of comment
-lines when typing extends beyond the right margin.  'r' enables the
+option:  "c", "r" and "o".  "c" enables auto-wrapping of comment
+lines when typing extends beyond the right margin.  "r" enables the
 automatic insertion of the comment leader when <Enter> is pressed
-while editing a comment line.  'o' enables the automatic insertion
+while editing a comment line.  "o" enables the automatic insertion
 of the comment leader when a new line is opened above or below an
 existing comment line by typing O or o in Normal mode.
 
 You can stop Vim from automatically inserting the comment leader
 when typing <Enter> within a comment or when opening a new line by
-removing the 'r' and 'o' flags from 'formatoptions'.
+removing the "r" and "o" flags from 'formatoptions'.
 
    :set formatoptions-=r
    :set formatoptions-=o
 
 The default filetype plugin for C and C++ files
-($VIMRUNTIME/ftplugin/c.vim) adds the 'r' and 'o' flags to the
+($VIMRUNTIME/ftplugin/c.vim) adds the "r" and "o" flags to the
 'formatoptions' option.  If you want to override this for C++ files,
 then you can add the above lines to the
 ~/.vim/after/ftplugin/cpp.vim file.
@@ -7189,11 +7175,11 @@ For more information, read:
     |ftplugin-overrule|
 
  								*faq-27.8*
-27.8. How do I add the comment character '#' to a set of lines at the
+27.8. How do I add the comment character "#" to a set of lines at the
       beginning of each line?
 
 First, select the first character in all the lines using visual block mode
-(CTRL-V). Press 'I' to start inserting characters at the beginning of the
+(CTRL-V). Press "I" to start inserting characters at the beginning of the
 line. Enter the comment character and then stop the insert mode by pressing
 <Esc>. Vim will automatically insert the entered characters at the
 beginning of all the selected lines.
@@ -7218,8 +7204,8 @@ You can use the following command to edit the file in a new split window: >
     :sp %:t:r.h
 <
 In the above commands, the percent sign expands to the name of the current
-file.  The ":t" modifier extracts the tail (last component) of the
-filename. The ":r" modifier extracts the root of the filename.  The .h is
+file.  The `:t` modifier extracts the tail (last component) of the
+filename. The `:r` modifier extracts the root of the filename.  The .h is
 appended to the resulting name to get the header filename.
 
 Another approach is to use the following command: >
@@ -7239,13 +7225,13 @@ For more information, read:
  								*faq-27.10*
 27.10. How do I automatically insert comment leaders while typing comments?
 
-To automatically insert comment leaders while typing comments, add the 'r'
-and 'o' flags to the 'formatoptions' option. >
+To automatically insert comment leaders while typing comments, add the "r"
+and "o" flags to the 'formatoptions' option. >
 
     :set formatoptions+=ro
 <
-You may also want to add the 'c' flag to auto-wrap comments using the
-'textwidth' option setting and the 'q' flag to format comments with the
+You may also want to add the "c" flag to auto-wrap comments using the
+'textwidth' option setting and the "q" flag to format comments with the
 "gq" command: >
 
     :set formatoptions=croq
@@ -7264,7 +7250,7 @@ SECTION 28 - QUICKFIX ~
  								*faq-28.1*
 28.1. How do I build programs from Vim?
 
-You can use the ":make" command to build programs from Vim. The ":make"
+You can use the `:make` command to build programs from Vim. The `:make`
 command runs the program specified by the 'makeprg' option.
 
 For more information, read:
@@ -7279,10 +7265,10 @@ For more information, read:
  								*faq-28.2*
 28.2. When I run the make command in Vim I get the errors listed as the
       compiler compiles the program. When it finishes this list disappears
-      and I have to use the  :clist command to see the error message again.
+      and I have to use the `:clist` command to see the error message again.
       Is there any other way to see these error messages?
 
-You can use the ":copen" or ":cwindow" command to open the quickfix window
+You can use the `:copen` or `:cwindow` command to open the quickfix window
 that contains the compiler output. You can select different error lines
 from this window and jump to the corresponding line in the source code.
 
@@ -7296,13 +7282,13 @@ For more information, read:
 28.3. How can I perform a command for each item in the quickfix/location
       list?
 
-Starting from Vim 7.4.858 Vim provides the new commands :cfdo, :cdo,
-:lfdo and :ldo. They work by iterating over all items in the quickfix
-list and performing a command on each. The difference is, that the :lfdo
-and :ldo commands iterate over the location list entries, while the
-:cfdo and :cdo commands operate on the items in the quickfix list. Also,
-the :cfdo and :lfdo operate on all different files, while the :cdo and
-:ldo commands operate on each item in the quickfix/location list.
+Starting from Vim 7.4.858 Vim provides the new commands `:cfdo`, `:cdo`,
+`:lfdo` and `:ldo.` They work by iterating over all items in the quickfix
+list and performing a command on each. The difference is, that the `:lfdo`
+and `:ldo` commands iterate over the location list entries, while the
+`:cfdo` and `:cdo` commands operate on the items in the quickfix list. Also,
+the `:cfdo` and `:lfdo` operate on all different files, while the `:cdo` and
+`:ldo` commands operate on each item in the quickfix/location list.
 
 For example you could vimgrep all C files in the current directory for a
 search string "Foobar": >
@@ -7417,8 +7403,8 @@ For more information, read:
 29.6. How do I store and restore manually created folds across different
       Vim invocations?
 
-You can use the ":mkview" command to store manually created folds. Later,
-you can use the ":loadview" command to restore the folds. For this to work,
+You can use the `:mkview` command to store manually created folds. Later,
+you can use the `:loadview` command to restore the folds. For this to work,
 the 'viewoptions' must contain "folds".
 
 For more information, read:
@@ -7464,11 +7450,11 @@ and interact with the shell using the normal Vim commands.
 When the focus is in the terminal window, typed keys will be sent to
 the job and is called terminal mode. You can click outside of the
 terminal window to move keyboard focus elsewhere, alternatively one can
-use Ctrl-W to novigate between different Vim windows. To feed Ctrl-W into the
+use CTRL-W to novigate between different Vim windows. To feed CTRL-W into the
 terminal, one needs to use CTRL-W .
 
-To map keys specifically for terminal mode, use the new :tmap
-command. After typing Ctrl-W the terminal window will switch to
+To map keys specifically for terminal mode, use the new `:tmap`
+command. After typing CTRL-W the terminal window will switch to
 Terminal-Normal mode (this can be used to move the cursor around, scroll
 the window, etc. Just like normal mode).
 
@@ -7498,7 +7484,7 @@ For more information, read:
  								*faq-30.3*
 30.3. How do I get the output of a shell command into a Vim buffer?
 
-You can use the ":r !" command to get the output of a shell command into a
+You can use the `:r !` command to get the output of a shell command into a
 Vim buffer. For example, to insert the output of the "ls" shell command,
 you can use the following command: >
 
@@ -7535,7 +7521,7 @@ results back in the buffer, you can use >
     :w !sort
 <
 The above command will pipe the entire buffer to the sort command.  Note,
-that the space between the 'w' and the '!' is critical.  To pipe only a
+that the space between the "w" and the "!" is critical.  To pipe only a
 range of lines, you can use >
 
     :10,20w !sort
@@ -7551,11 +7537,11 @@ For more information, read:
  								*faq-30.5*
 30.5. How do I sort a section of my file?
 
-You use the ":sort" command like this:
+You use the `:sort` command like this:
 
    :5,100sort
 
-Using the ":sort" command provides many options, you can sort numerical on
+Using the `:sort` command provides many options, you can sort numerical on
 the first found decimal number using:
 
    :%sort n
@@ -7708,7 +7694,7 @@ For more information, read:
  								*faq-31.5*
 31.5. How do I make the scrollbar appear in the left side by default?
 
-You can add the 'l' flag to the 'guioptions' option to make the scrollbar
+You can add the "l" flag to the 'guioptions' option to make the scrollbar
 appear in the left side. >
 
     :set guioptions+=l
@@ -7722,7 +7708,7 @@ For more information, read:
  								*faq-31.6*
 31.6. How do I remove the Vim menubar?
 
-You can remove the Vim menubar by removing the 'm' flag from the
+You can remove the Vim menubar by removing the "m" flag from the
 'guioptions' option: >
 
     :set guioptions-=m
@@ -7732,11 +7718,11 @@ For more information, read:
     |'guioptions'|
 
  								*faq-31.7*
-31.7. I am using GUI Vim. When I press the ALT key and a letter, the menu
+31.7. I am using GUI Vim. When I press the <Alt> key and a letter, the menu
       starting with that letter is selected. I don't want this behavior as
-      I want to map the ALT-<key> combination. How do I do this?
+      I want to map the <Alt>-<key> combination. How do I do this?
 
-You can use the 'winaltkeys' option to disable the use of the ALT key to
+You can use the 'winaltkeys' option to disable the use of the <Alt> key to
 select a menu item: >
 
     :set winaltkeys=no
@@ -7767,10 +7753,10 @@ For more information, read:
 
  								*faq-31.9*
 31.9. How do I get gvim to start browsing files in a particular directory
-      when using the ":browse" command?
+      when using the `:browse` command?
 
 You can set the 'browsedir' option to the default directory to use for the
-":browse" command. >
+`:browse` command. >
 
     :set browsedir='<your_dir>'
 <
@@ -7783,7 +7769,7 @@ For more information, read:
        displays a GUI dialog box. How do I replace this GUI dialog box with
        a console dialog box?
 
-You can set the 'c' flag in the 'guioptions' option to configure Vim to use
+You can set the "c" flag in the 'guioptions' option to configure Vim to use
 console dialogs instead of GUI dialogs: >
 
     :set guioptions+=c
@@ -7799,7 +7785,7 @@ For more information, read:
        GUI Vim, so that the control returns to the xxx application only
        after I quit Vim?
 
-You have to start GUI Vim with the '-f' (foreground) command line option: >
+You have to start GUI Vim with the "-f" (foreground) command line option: >
 
     $ gvim -f
 <
@@ -7828,7 +7814,7 @@ For more information, read:
  								*faq-31.13*
 31.13. How do I use the mouse in Vim command-line mode?
 
-You can set the 'c' flag in the 'mouse' option to use mouse in the Vim
+You can set the "c" flag in the 'mouse' option to use mouse in the Vim
 command-line mode: >
 
     :set mouse+=c
@@ -7857,8 +7843,8 @@ For more information, read:
  								*faq-31.15*
 31.15. How do I change the location and size of a GUI Vim window?
 
-You can use the "winpos" command to change the Vim window position. To
-change the size of the window, you can modify the "lines" and "columns"
+You can use the `:winpos` command to change the Vim window position. To
+change the size of the window, you can modify the 'lines' and 'columns'
 options.
 
 For example, the following commands will position the GUI Vim window at the
@@ -7869,7 +7855,7 @@ columns to 80. >
     :set lines=50
     :set columns=80
 <
-The arguments to the 'winpos' command specify the pixel co-ordinates of the
+The arguments to the `:winpos` command specify the pixel co-ordinates of the
 Vim window. The 'lines' and 'columns' options specify the number of lines
 and characters to use for the height and the width of the window
 respectively.
@@ -7914,7 +7900,7 @@ When you press the CTRL-S key, the terminal driver will stop sending the
 output data. As a result of this, it will look like Vim is hung. If you
 press the CTRL-Q key, then everything will be back to normal.
 
-You can turn off the terminal driver flow control using the 'stty' command: >
+You can turn off the terminal driver flow control using the "stty" command: >
 
     $ stty -ixon -ixoff
 <
@@ -7945,7 +7931,7 @@ key. You can try using the command: >
     :fixdel
 <
 Make sure the TERM environment variable is set to the correct terminal
-name. You can try using the 'stty' command: >
+name. You can try using the "stty" command: >
 
     $ stty erase ^H
 <
@@ -8060,19 +8046,19 @@ For more information, read:
     |gui-gtk|
 
  								*faq-32.8*
-32.8. How do I prevent <Ctrl-Z> from suspending Vim?
+32.8. How do I prevent CTRL-Z from suspending Vim?
 
-You can map <Ctrl-Z> to prevent the suspending. Here are some suggestions:
+You can map CTRL-Z to prevent the suspending. Here are some suggestions:
 
-- Make <Ctrl-Z> do nothing: >
+- Make CTRL-Z do nothing: >
 
     :map <C-Z> <Nop>
 <
-- Make <Ctrl-Z> start a shell: >
+- Make CTRL-Z start a shell: >
 
     :map <C-Z> :shell<CR>
 <
-- Make <Ctrl-Z> give an error message: >
+- Make CTRL-Z give an error message: >
 
     :map <C-Z> :"suspending disabled<CR>
 <
@@ -8151,14 +8137,14 @@ For more information, read:
 
 The mapping of the CTRL-Y key to the CTRL-R key is done by the mswin.vim
 script. The mswin.vim script maps CTRL-Y to make Vim behave like a standard
-MS-Windows application. This is explained in ":help CTRL-Y". You can either
+MS-Windows application. This is explained in `:help CTRL-Y`. You can either
 comment out the line in mswin.vim that maps the CTRL-Y key or you can
 remove the line in your .vimrc file that sources the mswin.vim script.
 
  								*faq-33.3*
 33.3. How do I start GUI Vim in a maximized window always?
 
-You can use the "simalt" command to maximize the Vim window. You can use
+You can use the `:simalt` command to maximize the Vim window. You can use
 the GUIEnter autocmd to maximize the Vim window on startup: >
 
     autocmd GUIEnter * simalt ~x
@@ -8292,7 +8278,7 @@ SECTION 34 - PRINTING ~
  								*faq-34.1*
 34.1. How do I print a file along with line numbers for all the lines?
 
-You can set the 'printoptions' option and use the ":hardcopy" command to
+You can set the 'printoptions' option and use the `:hardcopy` command to
 print your file: >
 
     :set printoptions=number:y
@@ -8306,7 +8292,7 @@ For more information, read:
  								*faq-34.2*
 34.2. How do I print a file with the Vim syntax highlighting colors?
 
-You can use the ":hardcopy" command to print a file with the Vim syntax
+You can use the `:hardcopy` command to print a file with the Vim syntax
 highlighting colors. You can also convert your file to a HTML file using
 the 2html.vim script and print the HTML file.
 
@@ -8336,14 +8322,14 @@ For a Unix system, follow these steps to build Vim from the sources:
   https://github.com/vim/vim/releases/
 - Alternatively, download the source from the mercurial repository:
   https://bitbucket.org/vim-mirror/vim/downloads/
-- Run the 'make' command to configure and build Vim with the default
+- Run the "make" command to configure and build Vim with the default
   configuration.
-- Run 'make install' command to install Vim in the default directory.
+- Run "make install" command to install Vim in the default directory.
 
-To enable/disable various Vim features, before running the 'make' command
-you can run the 'configure' command with different flags to include/exclude
+To enable/disable various Vim features, before running the "make" command
+you can run the "configure" command with different flags to include/exclude
 the various Vim features. To list all the available options for the
-'configure' command, use: >
+"configure" command, use: >
 
     $ configure --help
 <
@@ -8427,7 +8413,7 @@ you can remove the source directory.
 35.6. How do I determine the Vim features which are enabled at compile
       time?
 
-You can use the ":version" command to determine the Vim features that are
+You can use the `:version` command to determine the Vim features that are
 enabled at compile time. The features that are enabled will be prefixed
 with a "+". The features that are not enabled will be prefixed with a "-".
 
@@ -8484,7 +8470,7 @@ Vim and not the system's provided version. So first check your $PATH
 setting.
 
 Depending on your compile options, some features might not be included in
-your build of Vim. You can use the ":version" command to determine the Vim
+your build of Vim. You can use the `:version` command to determine the Vim
 features that are enabled at compile time. The features that are enabled
 will be prefixed with a "+". The features that are not enabled will be
 prefixed with a "-".
@@ -8615,7 +8601,7 @@ For more information, read:
 36.3. How do I display the ascii value of a character displayed in a
       buffer?
 
-You can use the 'ga' command to display the ascii value of a displayed
+You can use the "ga" command to display the ascii value of a displayed
 character.
 
 For more information, read:
@@ -8637,7 +8623,7 @@ For more information, read:
  								*faq-36.5*
 36.5. How do I disable the Vim welcome screen?
 
-You can disable the Vim welcome screen, by adding the 'I' flag to the
+You can disable the Vim welcome screen, by adding the "I" flag to the
 'shortmess' option: >
 
     :set shortmess+=I
@@ -8652,7 +8638,7 @@ For more information, read:
 
 Vim will prompt you with the "hit enter to continue" prompt, if there are
 some messages on the screen for you to read and the screen is about to be
-redrawn.  You can add the 'T' flag to the 'shortmess' option to truncate
+redrawn.  You can add the "T" flag to the 'shortmess' option to truncate
 all messages. This will help in avoiding the hit-enter prompt: >
 
     :set shortmess+=T
@@ -8730,7 +8716,7 @@ For more information, read:
  								*faq-36.9*
 36.9. How do I start Vim in insert mode?
 
-You can start Vim in insert mode using the ":startinsert" ex command. >
+You can start Vim in insert mode using the `:startinsert` ex command. >
 
     $ vim +startinsert myfile.txt
 <
@@ -8748,7 +8734,7 @@ For more information, read:
  								*faq-36.10*
 36.10. How do I use Copy and Paste with Vim?
 
-You should first check the output of the ":version" command and make
+You should first check the output of the `:version` command and make
 sure that +xterm-clipboard is present.
 
 When running Vim in an xterm, you can either let Vim control the mouse
@@ -8760,7 +8746,7 @@ mouse. When you select some text using the mouse, xterm will copy
 it to the X11 cut buffer. When you press both the mouse buttons,
 xterm will paste the text from the cut buffer.
 
-If the 'mouse' option is set to 'a' or some other value, then Vim controls
+If the 'mouse' option is set to "a" or some other value, then Vim controls
 the mouse. The mode (normal or insert or visual, etc) in which Vim
 controls the mouse is configured by the 'mouse' option. You can move
 the Vim text cursor using the mouse. When you select some text,
@@ -8956,11 +8942,11 @@ Several methods are available:
   those which require a "dead-key" prefix, like (for instance) the
   circumflex on French keyboards.
 - Characters for which a digraph is defined can be typed as two characters
-  prefixed by <Ctrl-K>.
+  prefixed by CTRL-K.
 - If you have set the 'digraph' option, you can enter the characters for
   which a digraph is defined as <char1><BS><char2>.
-- Any character can be entered by using a <Ctrl-V> prefix (or <Ctrl-Q> if
-  <Ctrl-V> is remapped to paste from the clipboard).
+- Any character can be entered by using a CTRL-V prefix (or CTRL-Q if
+  CTRL-V is remapped to paste from the clipboard).
 
 For more information, read:
 
@@ -8972,7 +8958,7 @@ For more information, read:
 37.12. How can I know which digraphs are defined and for which characters?
 
 First set the 'encoding' option properly (for instance, to utf-8), then use
-the :digraphs command to list the currently defined digraphs.
+the `:digraphs` command to list the currently defined digraphs.
 
 Alternatively, the help file contains the complete set of all digraphs.
 So you can easily search that list there.


### PR DESCRIPTION
Regenerate vim_faq.txt.

```
make help
```

fix below:

* some quote char
* 1/4 unicode char